### PR TITLE
Remove the rest of the development GitHub auth provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,6 @@ KCC_SERVICEACCOUNT_EMAIL=
 BACKSTAGE_CONTAINER_REGISTRY=northamerica-northeast1-docker.pkg.dev/pht-01hsv4d2m0n/ph-backstage
 BACKSTAGE_CONTAINER_TAG=latest
 
-# Backstage Auth
-AUTH_GITHUB_CLIENT_ID=
-AUTH_GITHUB_CLIENT_SECRET=
-
 # Backstage Template
 GITOPS_REPO_OWNER=PHACDataHub
 GITOPS_REPO_NAME=sci-portal

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -79,19 +79,15 @@ techdocs:
 auth:
   environment: development
   providers:
-    # See https://backstage.io/docs/auth/github/provider
-    github:
-      development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
-
-        # Authentication will fail without at least one resolver
-        signIn:
-          resolvers:
-            - resolver: usernameMatchingUserEntityName
-
     # See https://backstage.io/docs/auth/guest/provider
     guest: {}
+    google:
+      development:
+        clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityAnnotation
 
 scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options

--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -43,7 +43,6 @@ import LightIcon from '@material-ui/icons/WbSunny';
 import { UnifiedThemeProvider } from '@backstage/theme';
 import { GovTheme } from './theme/govTheme';
 import { HomepageCompositionRoot } from '@backstage/plugin-home';
-import { githubAuthApiRef } from '@backstage/core-plugin-api';
 import { googleAuthApiRef } from '@backstage/core-plugin-api';
 import { CostDashboardPage } from './components/costDashboard/CostDashboardPage';
 
@@ -53,12 +52,6 @@ const app = createApp({
       <SignInPage
         {...props}
         providers={[
-          {
-            id: 'github-auth-provider',
-            title: 'GitHub',
-            message: 'Sign in using GitHub',
-            apiRef: githubAuthApiRef,
-          },
           {
             id: 'google-auth-provider',
             title: 'Google',


### PR DESCRIPTION
### Proposed Changes

- Replace the development GitHub auth provider with Google