### PR TITLE
Install provider-kubernetes crossplane provider

### DIFF
--- a/root-sync/base/crossplane/kubernetes.yaml
+++ b/root-sync/base/crossplane/kubernetes.yaml
@@ -1,0 +1,38 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.13.0
+  runtimeConfigRef:
+    name: provider-kubernetes
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: kubernetes-provider
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-kubernetes
+spec:
+  serviceAccountTemplate:
+    metadata:
+      name: provider-kubernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provider-kubernetes-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: provider-kubernetes
+    namespace: crossplane-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/root-sync/base/crossplane/kustomization.yaml
+++ b/root-sync/base/crossplane/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - xrd-project.yaml
-  - composition-project.yaml 
+  - kubernetes.yaml
+  # - xrd-project.yaml
+  # - composition-project.yaml 


### PR DESCRIPTION
- Install Crossplane provider provider-kubernetes from https://github.com/crossplane-contrib/provider-kubernetes.
- Disable XRD and composition.
 - Claim name collision causing troubleshooting/observability issue. Will rename claim in future PR.