### PR TITLE
Check manifests

### DIFF
--- a/.github/workflows/pr-root-sync.yaml
+++ b/.github/workflows/pr-root-sync.yaml
@@ -29,6 +29,28 @@ jobs:
       - name: Install nomos
         run: gcloud components install nomos
 
-      - name: Check manifests
+      - name: Check Config Connector resources
         run: nomos vet --clusters "" --no-api-server-check --source-format unstructured
         # Refer to the docs https://cloud.google.com/anthos-config-management/docs/how-to/nomos-command#vet
+
+      - name: Check manifests in base/
+        working-directory: ./root-sync/base
+        run: |
+          set -euxo pipefail
+          kustomize build . \
+          | kubeconform \
+            -verbose -strict \
+            -ignore-missing-schemas \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+      - name: Check manifests in overlays/test/
+        working-directory: ./root-sync/overlays/test
+        run: |
+          set -euxo pipefail
+          kustomize build . \
+          | kubeconform \
+            -verbose -strict \
+            -ignore-missing-schemas \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/devbox.json
+++ b/devbox.json
@@ -3,6 +3,7 @@
   "packages": [
     "go-task@3.36.0",
     "k9s@0.32.4",
+    "kubeconform@0.6.4",
     "kubectl@1.29.4",
     "kubernetes-helm@3.14.4",
     "shellcheck@0.10.0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -145,6 +145,54 @@
         }
       }
     },
+    "kubeconform@0.6.4": {
+      "last_modified": "2024-04-19T17:36:04-04:00",
+      "resolved": "github:NixOS/nixpkgs/92d295f588631b0db2da509f381b4fb1e74173c5#kubeconform",
+      "source": "devbox-search",
+      "version": "0.6.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qqjnwv66m07r58g8r81m0ggz8xjihdrx-kubeconform-0.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qqjnwv66m07r58g8r81m0ggz8xjihdrx-kubeconform-0.6.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lfdvlzix4qk1vrxjdssjzfrjrx2klyyx-kubeconform-0.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lfdvlzix4qk1vrxjdssjzfrjrx2klyyx-kubeconform-0.6.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kmv8y01r3z2k66hzjp1dydz33jxklraq-kubeconform-0.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kmv8y01r3z2k66hzjp1dydz33jxklraq-kubeconform-0.6.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y7s7lhrgiwdpl6l4lr9xazjra3j9kmla-kubeconform-0.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y7s7lhrgiwdpl6l4lr9xazjra3j9kmla-kubeconform-0.6.4"
+        }
+      }
+    },
     "kubectl@1.29.4": {
       "last_modified": "2024-04-19T17:36:04-04:00",
       "resolved": "github:NixOS/nixpkgs/92d295f588631b0db2da509f381b4fb1e74173c5#kubectl",


### PR DESCRIPTION
This closed #109.

### Proposed Changes

- Run `kustomize build` and `kubeconform` to check the manifests

### Notes

- `kubeconform` requires CRD schemas to be defined as a JSON schema. We're missing a few CRDs for now. I've created #x to follow up.
