### PR TITLE
Add feature toggle to opt-in to closing PRs 

### DIFF
--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -62,6 +62,13 @@ const app = createApp({
       />
     ),
   },
+  featureFlags: [
+    {
+      pluginId: '', // Blank for an app-level feature flag.
+      name: 'template-developer',
+      description: 'Enables additional features for Template development.',
+    },
+  ],
   themes: [
     {
       id: 'gov-theme',

--- a/backstage/templates/resource-provisioner.yaml
+++ b/backstage/templates/resource-provisioner.yaml
@@ -60,6 +60,15 @@ spec:
           ui:options:
             rows: 8
           ui:placeholder: jane.doe@gmail.com, john.doe@gmail.com, steve.smith@gmail.com
+    - title: Pull Request
+      backstage:featureFlag: template-developer
+      properties:
+        closePullRequest:
+          title: Close Pull Request?
+          type: boolean
+          default: true
+          ui:widget: radio
+          ui:description: Add the `[Test] ` prefix to close the pull request.
   steps:
     - id: create_resource
       name: Processing Request
@@ -78,8 +87,7 @@ spec:
       action: publish:github:pull-request
       input:
         repoUrl: github.com?owner=${{ steps.create_resource.output.repo_owner }}&repo=${{ steps.create_resource.output.repo_name }}
-        update: true
-        title: '[Test] Create ${{steps.create_resource.output.resource_type}}'
+        title: ${{ "[Test] " if parameters.closePullRequest else '' }}Create ${{steps.create_resource.output.resource_type}}
         branchName: request-${{steps.create_resource.output.request_id}}
         description: |
           # Create ${{steps.create_resource.output.resource_type}}


### PR DESCRIPTION
### Proposed Changes

- Declare the `template-developer` feature flag
- When the feature flag is enabled, show an additional step to opt-in to closing the PR

### Screenshots

Enable the Feature Flag from the User Profile:

<img width="1440" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/5c1ceab7-d445-4659-9ff8-842fdba64b4d">

When enabled, we'll see the new step in the Software Template:

<img width="1443" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/36eea349-f5b7-4732-9c45-f28925d70e79">
