### PR TITLE
Add `include_build_logs`

### DIFF
--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -27,9 +27,9 @@ resource "google_cloudbuild_trigger" "data_science_portal_trigger" {
       branch = var.cloudbuild_repository_branch
     }
   }
-  included_files = "backstage/**"
+  included_files     = "backstage/**"
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
-  filename       = "cloudbuild.yaml"
+  filename           = "cloudbuild.yaml"
 }
 
 module "gke" {

--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -28,6 +28,7 @@ resource "google_cloudbuild_trigger" "data_science_portal_trigger" {
     }
   }
   included_files = "backstage/**"
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
   filename       = "cloudbuild.yaml"
 }
 


### PR DESCRIPTION
This flag sends build logs to GitHub. More info [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger.html#include_build_logs).

I've enabled this on the console along with the `included_files` filter. Since you don't have access to the trigger and logs (I assume), you can view the build logs within GitHub.