### PR TITLE
Handle Object and KCC States

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -65,8 +65,11 @@ gcloud billing accounts list
 ### Enable the following APIs
 
 - Artifact Registry API (`artifactregistry.googleapis.com`)
+- Cloud Billing API (cloudbilling.googleapis.com)
+- Cloud Billing Budget API (`billingbudgets.googleapis.com`)
 - Cloud Build API (`cloudbuild.googleapis.com`)
 - Secret Manager API (`secretmanager.googleapis.com`)
+- Service Usage API (serviceusage.googleapis.com)
 
 ### Create a Cloud Build Connection
 

--- a/bootstrap/gke-cluster/services.tf
+++ b/bootstrap/gke-cluster/services.tf
@@ -59,3 +59,27 @@ resource "google_project_service" "server_networking" {
 
   disable_dependent_services = true
 }
+
+resource "google_project_service" "serviceusage_api" {
+  project = var.project_id
+  service = "serviceusage.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "cloudbilling_api" {
+  project = var.project_id
+  service = "cloudbilling.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: project
+  annotations:
+    crossplane.io/composition-schema-aware-validation-mode: strict
   labels:
     provider: kubernetes
     guide: self
@@ -23,6 +25,7 @@ spec:
               kind: Folder
               metadata:
                 name: "TO BE PATCHED"
+                namespace: default
               spec:
                 displayName: "TO BE PATCHED"
                 folderRef:
@@ -34,13 +37,10 @@ spec:
           toFieldPath: "spec.forProvider.manifest.spec.displayName"
         - fromFieldPath: "spec.rootFolderId"
           toFieldPath: "spec.forProvider.manifest.spec.folderRef.external"
-        - type: ToCompositeFieldPath 
-          fromFieldPath: "status.atProvider.manifest.status.folderId" # pass folderId to status
-          toFieldPath: status.folderId
 
       readinessChecks:
         - type: NonEmpty
-          fieldPath: status.atProvider.manifest.status.folderId # check if folder is created
+          fieldPath: status.atProvider.manifest
 
     - name: PROJECT
       base:
@@ -55,34 +55,47 @@ spec:
               kind: Project
               metadata:
                 name: "TO BE PATCHED"
+                namespace: default
                 annotations:
                   cnrm.cloud.google.com/auto-create-network: "false"
               spec:
                 name: "TO BE PATCHED"
-                resourceID: "TO BE PATCHED"
+                # resourceID: "TO BE PATCHED" -- xulid is too long
                 folderRef:
                   external: "TO BE PATCHED"
                 billingAccountRef:
                   external: "TO BE PATCHED"
           references:
+            - dependsOn:
+                apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+                kind: Folder
+                name: "TO BE PATCHED"
+                namespace: default
+            - patchesFrom:
+                apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+                kind: Folder
+                name: "TO BE PATCHED"
+                namespace: default
+                fieldPath: "status.folderId"
+              toFieldPath: "spec.folderRef.external"
             - patchesFrom:
                 apiVersion: v1
                 kind: ConfigMap
-                namespace: default
+                namespace: backstage
                 name: backstage-config
                 fieldPath: data.GCP_BILLING_ACCOUNT_ID
               toFieldPath: spec.billingAccountRef.external
       patches:
-        - fromFieldPath: "spec.projectId"
+        - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.metadata.name"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.name"
-        - fromFieldPath: "spec.projectId"
-          toFieldPath: "spec.forProvider.manifest.spec.resourceID"
-        - type: FromCompositeFieldPath # use folderId from status
-          fromFieldPath: "status.folderId"
-          toFieldPath: "spec.forProvider.manifest.spec.folderRef.external"
-      
+        # - fromFieldPath: "spec.projectId" -- xulid is too long
+        #   toFieldPath: "spec.forProvider.manifest.spec.resourceID"
+        - fromFieldPath: "spec.folderName"
+          toFieldPath: "spec.references[0].dependsOn.name"
+        - fromFieldPath: "spec.folderName"
+          toFieldPath: "spec.references[1].patchesFrom.name"
       readinessChecks:
         - type: NonEmpty
-          fieldPath: status.atProvider.manifest.status.number  # check if project is created
+          fieldPath: status.atProvider.manifest

--- a/root-sync/base/crossplane/project/xrd-project.yaml
+++ b/root-sync/base/crossplane/project/xrd-project.yaml
@@ -36,8 +36,3 @@ spec:
               - folderName
               - projectName
               - projectId
-          status:
-            type: object
-            properties:
-              folderId:
-                type: string


### PR DESCRIPTION
- Removed unused `status` property from xrd
- Enabled composition `composition-schema-aware-validation-mode`
- Re-added namespace
  - If namespace is not defined resources do not get created
- Disabled custom project id
  - xulid generated values are too long 
- Enabled more required apis 