### PR TITLE
Configure sign-in to use a redirect flow with no pop-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,3 @@ AUTH_GOOGLE_ALLOWED_DOMAINS=gcp.hc-sc.gc.ca,focisolutions.com
 # Backstage Templates
 GITOPS_REPO_OWNER=PHACDataHub
 GITOPS_REPO_NAME=sci-portal
-

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -73,3 +73,6 @@ auth:
   # We configure a custom sign-in resolver until we can manage Users and Groups with Secure LDAP.
   # See https://backstage.io/docs/auth/identity-resolver#sign-in-without-users-in-the-catalog
   allowedDomains: ${AUTH_GOOGLE_ALLOWED_DOMAINS}
+
+# Sign in without a pop-up. See https://backstage.io/docs/auth/#sign-in-configuration.
+enableExperimentalRedirectFlow: true

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -71,6 +71,9 @@ auth:
   # See https://backstage.io/docs/auth/identity-resolver#sign-in-without-users-in-the-catalog
   allowedDomains: ${AUTH_GOOGLE_ALLOWED_DOMAINS}
 
+# Sign in without a pop-up. See https://backstage.io/docs/auth/#sign-in-configuration.
+enableExperimentalRedirectFlow: true
+
 costInsights:
   engineerCost: 200000
   products:


### PR DESCRIPTION
### Proposed Changes

From the [Authentication in Backstage
](https://backstage.io/docs/auth/#:~:text=NOTE%3A%20You%20can%20configure%20sign%2Din%20to%20use%20a%20redirect%20flow%20with%20no%20pop%2Dup%20by%20adding%20enableExperimentalRedirectFlow%3A%20true%20to%20the%20root%20of%20your%20app%2Dconfig.yaml) documentation:

> NOTE: You can configure sign-in to use a redirect flow with no pop-up by adding `enableExperimentalRedirectFlow: true` to the root of your **app-config.yaml**

### Screenshots

There's no pop-up now:

<img width="2560" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/60148046-d890-4fc7-8818-65783ad33fad">

<img width="2560" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/ced680ea-f168-4940-a94c-fd6f6653f782">
