### PR TITLE
Fix the broken sign-in redirect

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -1,7 +1,7 @@
 ---
 app:
   # Should be the same as backend.baseUrl when using the `app-backend` plugin.
-  baseUrl: http://localhost:7007
+  baseUrl: https://backstage.alpha.phac-aspc.gc.ca
 
 backend:
   # Note that the baseUrl should be the URL that the browser and other clients
@@ -9,7 +9,7 @@ backend:
   # reachable not just from within the backend host, but from all of your
   # callers. When its value is "http://localhost:7007", it's strictly private
   # and can't be reached by others.
-  baseUrl: http://localhost:7007
+  baseUrl: https://backstage.alpha.phac-aspc.gc.ca
   # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
   # all interfaces, the most permissive setting. The right value depends on your specific deployment.
   listen: ':7007'


### PR DESCRIPTION
This closed #142.

### Proposed Changes

Fix the broken redirect to sign in to https://backstage.alpha.phac-aspc.gc.ca/.

<img width="2056" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/052e98a8-e494-44d7-b32d-ec7c61529066">

### Test Plan

This should work. I tried by modifying the Config Map and restart Backstage. 🎉 
