### PR TITLE
Fix the rootFolderId data type

### DIFF
--- a/DMIA-PHAC/SciencePlatform/ph-sean-dev1/project.yaml
+++ b/DMIA-PHAC/SciencePlatform/ph-sean-dev1/project.yaml
@@ -4,7 +4,7 @@ kind: ProjectClaim
 metadata:
   name: phx-sean-dev1-4b828d93-0732-4778-8071-0a1472fa2230
 spec:
-  rootFolderId: 108494461414
+  rootFolderId: '108494461414'
   folderName: ph-sean-dev1
   projectName: phx-sean-dev1
-  # projectId: 
+  # projectId:

--- a/backstage/templates/project-create/changes/project.yaml
+++ b/backstage/templates/project-create/changes/project.yaml
@@ -3,7 +3,7 @@ kind: ProjectClaim
 metadata:
   name: ${{values.projectName}}-${{values.requestId}}
 spec:
-  rootFolderId: ${{values.rootFolderId}}
+  rootFolderId: '${{values.rootFolderId}}'
   folderName: ${{values.folderName}}
   projectName: ${{values.projectName}}
   # projectId: ${{values.projectId}}


### PR DESCRIPTION
### Proposed Changes

Resolve the problem reported by [Config Sync](https://console.cloud.google.com/kubernetes/config_management/packages):

> KNV2009: failed to apply ProjectClaim.data-science-portal.phac-aspc.gc.ca, ...
> .spec.rootFolderId: **expected string**, ...
