### PR TITLE
Set the project ID

### DIFF
--- a/DMIA-PHAC/SciencePlatform/ph-sean-dev1/project.yaml
+++ b/DMIA-PHAC/SciencePlatform/ph-sean-dev1/project.yaml
@@ -7,4 +7,4 @@ spec:
   rootFolderId: '108494461414'
   folderName: ph-sean-dev1
   projectName: phx-sean-dev1
-  # projectId:
+  projectId: phx-sean-dev1

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -144,6 +144,7 @@ describe('provisioner', () => {
 
         **Folder Name:** ph-test-42
         **Project Name:** phx-test-42
+        **Project ID:** phx-test-42
 
         ### Administrative Details
 
@@ -173,6 +174,7 @@ describe('provisioner', () => {
           rootFolderId: '108494461414',
           folderName: 'ph-test-42',
           projectName: 'phx-test-42',
+          projectId: 'phx-test-42',
           budgetAlertEmailRecipients: [
             'jane.doe@gcp.hc-sc.gc.ca',
             'john.doe@gcp.hc-sc.gc.ca',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -164,6 +164,7 @@ export const createProvisionTemplateAction = (config: Config) => {
       ctx.output('folderName', folderName);
 
       const projectName = `${ctx.input.parameters.department}${ctx.input.parameters.environment}-${ctx.input.parameters.vanityName}`;
+      const projectId = projectName;
 
       // Render the Pull Request description template
       nunjucks.configure(templateDir);
@@ -178,6 +179,7 @@ export const createProvisionTemplateAction = (config: Config) => {
         rootFolderId,
         folderName,
         projectName,
+        projectId,
         budgetAlertEmailRecipients: parseEmailInput(
           ctx.input.parameters.budgetAlertEmailRecipients,
         ),

--- a/backstage/templates/project-create/changes/project.yaml
+++ b/backstage/templates/project-create/changes/project.yaml
@@ -7,4 +7,4 @@ spec:
   rootFolderId: '${{values.rootFolderId}}'
   folderName: ${{values.folderName}}
   projectName: ${{values.projectName}}
-  # projectId: ${{values.projectId}}
+  projectId: ${{values.projectId}}

--- a/backstage/templates/project-create/description.md.njk
+++ b/backstage/templates/project-create/description.md.njk
@@ -8,6 +8,7 @@ This PR was created using Backstage. The request ID is `{{requestId}}`.
 
 **Folder Name:** {{folderName}}
 **Project Name:** {{projectName}}
+**Project ID:** {{projectId}}
 
 ### Administrative Details
 


### PR DESCRIPTION
### Proposed Changes

Set the project ID to the project name to resolve the Config Sync error:

> KNV2009: failed to apply ProjectClaim.data-science-portal.phac-aspc.gc.ca, default/phx-sean-dev1-4b828d93-0732-4778-8071-0a1472fa2230: ProjectClaim.data-science-portal.phac-aspc.gc.ca "**phx-sean-dev1**-4b828d93-0732-4778-8071-0a1472fa2230" is invalid: **spec.projectId: Required value** For more information, see https://g.co/cloud/acm-errors#knv2009

This is a first step until we use the first 12 characters of the ULID for #111.
