### PR TITLE
Template Path Configuration

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -33,6 +33,12 @@ backend:
       #   ca: # if you have a CA file and want to verify it you can uncomment this section
       #     $file: <file-path>/ca/server.crt
 
+
+  plugins:
+    provisioner:
+      # Dockerfile copies all content from the 'templates' directory to the '/app' directory
+      templates: "/app"
+
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.
   # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -35,24 +35,19 @@ backend:
 
   plugins:
     provisioner:
-      # Dockerfile copies all content from the 'templates' directory to the '/app' directory
-      templateDir: '/app'
+      templateDir: '/app/templates'
 
 catalog:
-  # Overrides the default list locations from app-config.yaml as these contain example data.
-  # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
-  # on how to get entities into the catalog.
   locations:
     # Backstage entities
     - type: file
-      target: /app/entities.yaml
+      target: /app/templates/entities.yaml
       rules:
         - allow: [System, User, Group]
 
     # Resource Provisioner template
     - type: file
-      target: /app/resource-provisioner.yaml
-
+      target: /app/templates/resource-provisioner.yaml
       rules:
         - allow: [Template]
 

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -37,7 +37,7 @@ backend:
   plugins:
     provisioner:
       # Dockerfile copies all content from the 'templates' directory to the '/app' directory
-      templates: "/app"
+      templatesDir: "/app"
 
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -33,11 +33,10 @@ backend:
       #   ca: # if you have a CA file and want to verify it you can uncomment this section
       #     $file: <file-path>/ca/server.crt
 
-
   plugins:
     provisioner:
       # Dockerfile copies all content from the 'templates' directory to the '/app' directory
-      templateDir: "/app"
+      templateDir: '/app'
 
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -37,7 +37,7 @@ backend:
   plugins:
     provisioner:
       # Dockerfile copies all content from the 'templates' directory to the '/app' directory
-      templatesDir: "/app"
+      templateDir: "/app"
 
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -39,7 +39,7 @@ backend:
       repo:
         owner: ${GITOPS_REPO_OWNER}
         name: ${GITOPS_REPO_NAME}
-      templatesDir: "../../../../../../templates"
+      templateDir: "../../../../../../templates"
 
 integrations:
   github:

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -39,6 +39,7 @@ backend:
       repo:
         owner: ${GITOPS_REPO_OWNER}
         name: ${GITOPS_REPO_NAME}
+      templates: "../../../../../../templates"
 
 integrations:
   github:

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -39,7 +39,7 @@ backend:
       repo:
         owner: ${GITOPS_REPO_OWNER}
         name: ${GITOPS_REPO_NAME}
-      templateDir: "../../../../../../templates"
+      templateDir: '../../../../../../templates'
 
 integrations:
   github:

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -39,7 +39,7 @@ backend:
       repo:
         owner: ${GITOPS_REPO_OWNER}
         name: ${GITOPS_REPO_NAME}
-      templates: "../../../../../../templates"
+      templatesDir: "../../../../../../templates"
 
 integrations:
   github:

--- a/backstage/packages/backend/Dockerfile
+++ b/backstage/packages/backend/Dockerfile
@@ -45,7 +45,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
     yarn install --frozen-lockfile --production --network-timeout 300000
 
-COPY templates ./
+COPY --chown=node:node templates ./templates
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -298,14 +298,14 @@ describe('getConfig', () => {
                   owner: '<repo-owner>',
                   name: '<repo-name>',
                 },
-                templateDir: '/app',
+                templateDir: '/app/templates',
               },
             },
           },
         },
       });
       const actual = getConfig(rootConfig).templateDir;
-      const expected = '/app';
+      const expected = '/app/templates';
 
       expect(actual).toBe(expected);
     });

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -3,11 +3,32 @@ import {
   mockServices,
 } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
-import { createProvisionTemplateAction, parseEmailInput } from './provisioner';
+import {
+  createProvisionTemplateAction,
+  getConfig,
+  parseEmailInput,
+} from './provisioner';
 
 jest.mock('uuid', () => ({
   v4: jest.fn(() => '<uuid>'),
 }));
+
+const config = mockServices.rootConfig({
+  data: {
+    backend: {
+      plugins: {
+        provisioner: {
+          repo: {
+            owner: '<repo-owner>',
+            name: '<repo-name>',
+          },
+          templateDir: '../../../../../../templates',
+        },
+      },
+    },
+  },
+});
+const workspacePath = createMockDirectory().resolve('workspace');
 
 const createContext = ({ workspacePath }: { workspacePath: string }) => ({
   ...createMockActionContext({
@@ -44,22 +65,6 @@ const createContext = ({ workspacePath }: { workspacePath: string }) => ({
 
 describe('provisioner', () => {
   describe('data-science-portal:template:get-context', () => {
-    const config = mockServices.rootConfig({
-      data: {
-        backend: {
-          plugins: {
-            provisioner: {
-              repo: {
-                owner: '<repo-owner>',
-                name: '<repo-name>',
-              },
-            },
-          },
-        },
-      },
-    });
-    const workspacePath = createMockDirectory().resolve('workspace');
-
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -278,5 +283,31 @@ describe('parseEmailInput', () => {
     const expected: string[] = ['jane.doe@gcp.hc-sc.gc.ca'];
 
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('getConfig', () => {
+  describe('templateDir', () => {
+    it('should handle an absolute path', () => {
+      const rootConfig = mockServices.rootConfig({
+        data: {
+          backend: {
+            plugins: {
+              provisioner: {
+                repo: {
+                  owner: '<repo-owner>',
+                  name: '<repo-name>',
+                },
+                templateDir: '/app',
+              },
+            },
+          },
+        },
+      });
+      const actual = getConfig(rootConfig).templateDir;
+      const expected = '/app';
+
+      expect(actual).toBe(expected);
+    });
   });
 });

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -178,9 +178,9 @@ export const createProvisionTemplateAction = (config: Config) => {
 
       const requestId = uuidv4();
 
-      const provisionerConfig = getConfig(config);
-      ctx.output('repo_owner', provisionerConfig.repo.owner);
-      ctx.output('repo_name', provisionerConfig.repo.name);
+      const { repo, templateDir } = getConfig(config);
+      ctx.output('repo_owner', repo.owner);
+      ctx.output('repo_name', repo.name);
       ctx.output('branch', `request-${requestId}`);
 
       const template = ctx.templateInfo.entity.metadata.name;
@@ -193,7 +193,7 @@ export const createProvisionTemplateAction = (config: Config) => {
       const projectId = projectName;
 
       // Render the Pull Request description template
-      const env = nunjucks.configure(provisionerConfig.templateDir);
+      const env = nunjucks.configure(templateDir);
 
       // Add the map() filter from jinja into Nunjucks.
       // https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -17,10 +17,12 @@ interface ProvisionerConfig {
 }
 
 export const getConfig = (config: Config): ProvisionerConfig => {
-  const templateDir = path.join(
-    __dirname,
-    config.getString('backend.plugins.provisioner.templateDir'),
+  const rawTemplateDir = config.getString(
+    'backend.plugins.provisioner.templateDir',
   );
+  const templateDir = path.isAbsolute(rawTemplateDir)
+    ? rawTemplateDir
+    : path.join(__dirname, rawTemplateDir);
 
   return {
     repo: {

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -13,7 +13,7 @@ interface ProvisionerConfig {
     owner: string;
     name: string;
   };
-  templatesDir: string;
+  templateDir: string;
 }
 
 interface User extends JsonObject {
@@ -27,9 +27,9 @@ const toUser = (ownerEmail: string): User => ({
 });
 
 const getConfig = (config: Config): ProvisionerConfig => {
-  const templatesDir = path.join(
+  const templateDir = path.join(
     __dirname,
-    config.getString('backend.plugins.provisioner.templatesDir'),
+    config.getString('backend.plugins.provisioner.templateDir'),
   );
 
   return {
@@ -37,7 +37,7 @@ const getConfig = (config: Config): ProvisionerConfig => {
       owner: config.getString('backend.plugins.provisioner.repo.owner'),
       name: config.getString('backend.plugins.provisioner.repo.name'),
     },
-    templatesDir,
+    templateDir,
   };
 };
 
@@ -191,7 +191,7 @@ export const createProvisionTemplateAction = (config: Config) => {
       const projectId = projectName;
 
       // Render the Pull Request description template
-      const env = nunjucks.configure(provisionerConfig.templatesDir);
+      const env = nunjucks.configure(provisionerConfig.templateDir);
 
       // Add the map() filter from jinja into Nunjucks.
       // https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -6,7 +6,6 @@ import { InputError } from '@backstage/errors';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 
-const templateDir = path.join(__dirname, '../../../../../../templates');
 const rootFolderId = '108494461414';
 
 interface ProvisionerConfig {
@@ -14,6 +13,7 @@ interface ProvisionerConfig {
     owner: string;
     name: string;
   };
+  templates: string;
 }
 
 interface User extends JsonObject {
@@ -27,11 +27,17 @@ const toUser = (ownerEmail: string): User => ({
 });
 
 const getConfig = (config: Config): ProvisionerConfig => {
+  const templates = path.join(
+    __dirname,
+    config.getString('backend.plugins.provisioner.templates'),
+  );
+
   return {
     repo: {
       owner: config.getString('backend.plugins.provisioner.repo.owner'),
       name: config.getString('backend.plugins.provisioner.repo.name'),
     },
+    templates,
   };
 };
 
@@ -185,7 +191,7 @@ export const createProvisionTemplateAction = (config: Config) => {
       const projectId = projectName;
 
       // Render the Pull Request description template
-      const env = nunjucks.configure(templateDir);
+      const env = nunjucks.configure(provisionerConfig.templates);
 
       // Add the map() filter from jinja into Nunjucks.
       // https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -16,17 +16,7 @@ interface ProvisionerConfig {
   templateDir: string;
 }
 
-interface User extends JsonObject {
-  name: string;
-  email: string;
-}
-
-const toUser = (ownerEmail: string): User => ({
-  email: ownerEmail,
-  name: ownerEmail.split('@')[0],
-});
-
-const getConfig = (config: Config): ProvisionerConfig => {
+export const getConfig = (config: Config): ProvisionerConfig => {
   const templateDir = path.join(
     __dirname,
     config.getString('backend.plugins.provisioner.templateDir'),
@@ -44,6 +34,16 @@ const getConfig = (config: Config): ProvisionerConfig => {
 const validateConfig = (config: Config) => {
   getConfig(config);
 };
+
+interface User extends JsonObject {
+  name: string;
+  email: string;
+}
+
+const toUser = (ownerEmail: string): User => ({
+  email: ownerEmail,
+  name: ownerEmail.split('@')[0],
+});
 
 /**
  * Returns an array of unique email addresses, ignoring whitespace and extra commas.

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -13,7 +13,7 @@ interface ProvisionerConfig {
     owner: string;
     name: string;
   };
-  templates: string;
+  templatesDir: string;
 }
 
 interface User extends JsonObject {
@@ -27,9 +27,9 @@ const toUser = (ownerEmail: string): User => ({
 });
 
 const getConfig = (config: Config): ProvisionerConfig => {
-  const templates = path.join(
+  const templatesDir = path.join(
     __dirname,
-    config.getString('backend.plugins.provisioner.templates'),
+    config.getString('backend.plugins.provisioner.templatesDir'),
   );
 
   return {
@@ -37,7 +37,7 @@ const getConfig = (config: Config): ProvisionerConfig => {
       owner: config.getString('backend.plugins.provisioner.repo.owner'),
       name: config.getString('backend.plugins.provisioner.repo.name'),
     },
-    templates,
+    templatesDir,
   };
 };
 
@@ -191,7 +191,7 @@ export const createProvisionTemplateAction = (config: Config) => {
       const projectId = projectName;
 
       // Render the Pull Request description template
-      const env = nunjucks.configure(provisionerConfig.templates);
+      const env = nunjucks.configure(provisionerConfig.templatesDir);
 
       // Add the map() filter from jinja into Nunjucks.
       // https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map


### PR DESCRIPTION
This PR closes #163.

--

![image](https://github.com/PHACDataHub/sci-portal/assets/48633735/16131efa-b470-4a32-af44-b30a4a5fe0cd)

In our production environment, we've encountered situations where templates cannot be found by backstage. 

Changes
---
-  app-config.yaml and app-config.production.yaml files now have valid template paths tailored to each environment.