### PR TITLE
Project IAM Roles

### DIFF
--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -100,6 +100,63 @@ spec:
       readinessChecks:
         - type: NonEmpty
           fieldPath: status.atProvider.manifest
+    
+    - name: PROJECT-IAM
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          providerConfigRef:
+            name: kubernetes-provider
+          forProvider:
+            manifest:
+              apiVersion: iam.cnrm.cloud.google.com/v1beta1
+              kind: IAMPolicy
+              metadata:
+                name: "TO BE PATCHED"
+                namespace: default
+              spec:
+                resourceRef:
+                  kind: Project
+                  name: "TO BE PATCHED"
+                bindings:
+                  - role: roles/editor
+                    members:
+                      - "TO BE PATCHED"
+                  - role: roles/viewer
+                    members:
+                      - "TO BE PATCHED"
+                auditConfigs:
+                  - service: allServices
+                    auditLogConfigs:
+                      - logType: DATA_WRITE
+                      - logType: DATA_READ
+          references:
+            - dependsOn:
+                apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+                kind: Project
+                name: "TO BE PATCHED"
+                namespace: default
+      patches:
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.references[0].dependsOn.name"
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.forProvider.manifest.spec.resourceRef.name"
+        - fromFieldPath: "spec.projectEditors"
+          toFieldPath: "spec.forProvider.manifest.spec.bindings[0].members"
+        - fromFieldPath: "spec.projectViewers"
+          toFieldPath: "spec.forProvider.manifest.spec.bindings[1].members"
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.forProvider.manifest.metadata.name"
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "iampolicy-%s"
+
+      readinessChecks:
+        - type: NonEmpty
+          fieldPath: status.atProvider.manifest
 
     - name: BUDGET
       base:
@@ -172,63 +229,6 @@ spec:
                 fmt: "budget-%s"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.budgetFilter.projects[0].name"
-      readinessChecks:
-        - type: NonEmpty
-          fieldPath: status.atProvider.manifest
-
-    - name: BILLING-IAM
-      base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        spec:
-          providerConfigRef:
-            name: kubernetes-provider
-          forProvider:
-            manifest:
-              apiVersion: iam.cnrm.cloud.google.com/v1beta1
-              kind: IAMPolicy
-              metadata:
-                name: "TO BE PATCHED"
-                namespace: default
-              spec:
-                resourceRef:
-                  kind: Project
-                  name: "TO BE PATCHED"
-                bindings:
-                  - role: roles/editor
-                    members:
-                      - "TO BE PATCHED"
-                  - role: roles/viewer
-                    members:
-                      - "TO BE PATCHED"
-                auditConfigs:
-                  - service: allServices
-                    auditLogConfigs:
-                      - logType: DATA_WRITE
-                      - logType: DATA_READ
-          references:
-            - dependsOn:
-                apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-                kind: Project
-                name: "TO BE PATCHED"
-                namespace: default
-      patches:
-        - fromFieldPath: "spec.projectName"
-          toFieldPath: "spec.references[0].dependsOn.name"
-        - fromFieldPath: "spec.projectName"
-          toFieldPath: "spec.forProvider.manifest.spec.resourceRef.name"
-        - fromFieldPath: "spec.projectEditors"
-          toFieldPath: "spec.forProvider.manifest.spec.bindings[0].members"
-        - fromFieldPath: "spec.projectViewers"
-          toFieldPath: "spec.forProvider.manifest.spec.bindings[1].members"
-        - fromFieldPath: "spec.projectName"
-          toFieldPath: "spec.forProvider.manifest.metadata.name"
-          transforms:
-            - type: string
-              string:
-                type: Format
-                fmt: "iampolicy-%s"
-
       readinessChecks:
         - type: NonEmpty
           fieldPath: status.atProvider.manifest

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -172,3 +172,63 @@ spec:
                 fmt: "budget-%s"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.budgetFilter.projects[0].name"
+      readinessChecks:
+        - type: NonEmpty
+          fieldPath: status.atProvider.manifest
+
+    - name: BILLING-IAM
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          providerConfigRef:
+            name: kubernetes-provider
+          forProvider:
+            manifest:
+              apiVersion: iam.cnrm.cloud.google.com/v1beta1
+              kind: IAMPolicy
+              metadata:
+                name: "TO BE PATCHED"
+                namespace: default
+              spec:
+                resourceRef:
+                  kind: Project
+                  name: "TO BE PATCHED"
+                bindings:
+                  - role: roles/owner
+                    members:
+                      - "TO BE PATCHED"
+                  - role: roles/editor
+                    members:
+                      - "TO BE PATCHED"
+                auditConfigs:
+                  - service: allServices
+                    auditLogConfigs:
+                      - logType: DATA_WRITE
+                      - logType: DATA_READ
+          references:
+            - dependsOn:
+                apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+                kind: Project
+                name: "TO BE PATCHED"
+                namespace: default
+      patches:
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.references[0].dependsOn.name"
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.forProvider.manifest.spec.resourceRef.name"
+        - fromFieldPath: "spec.projectOwners"
+          toFieldPath: "spec.forProvider.manifest.spec.bindings[0].members"
+        - fromFieldPath: "spec.projectEditors"
+          toFieldPath: "spec.forProvider.manifest.spec.bindings[1].members"
+        - fromFieldPath: "spec.projectName"
+          toFieldPath: "spec.forProvider.manifest.metadata.name"
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "iampolicy-%s"
+
+      readinessChecks:
+        - type: NonEmpty
+          fieldPath: status.atProvider.manifest

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -195,10 +195,10 @@ spec:
                   kind: Project
                   name: "TO BE PATCHED"
                 bindings:
-                  - role: roles/owner
+                  - role: roles/editor
                     members:
                       - "TO BE PATCHED"
-                  - role: roles/editor
+                  - role: roles/viewer
                     members:
                       - "TO BE PATCHED"
                 auditConfigs:
@@ -217,9 +217,9 @@ spec:
           toFieldPath: "spec.references[0].dependsOn.name"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.resourceRef.name"
-        - fromFieldPath: "spec.projectOwners"
-          toFieldPath: "spec.forProvider.manifest.spec.bindings[0].members"
         - fromFieldPath: "spec.projectEditors"
+          toFieldPath: "spec.forProvider.manifest.spec.bindings[0].members"
+        - fromFieldPath: "spec.projectViewers"
           toFieldPath: "spec.forProvider.manifest.spec.bindings[1].members"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.metadata.name"

--- a/root-sync/base/crossplane/project/xrd-project.yaml
+++ b/root-sync/base/crossplane/project/xrd-project.yaml
@@ -32,8 +32,18 @@ spec:
                   type: string
                 projectId:
                   type: string
+                projectOwners:
+                  type: array
+                  items:
+                    type: string
+                projectEditors:
+                  type: array
+                  items:
+                    type: string
               required:
                 - rootFolderId
                 - folderName
                 - projectName
                 - projectId
+                - projectOwners
+                - projectEditors

--- a/root-sync/base/crossplane/project/xrd-project.yaml
+++ b/root-sync/base/crossplane/project/xrd-project.yaml
@@ -32,11 +32,11 @@ spec:
                   type: string
                 projectId:
                   type: string
-                projectOwners:
+                projectEditors:
                   type: array
                   items:
                     type: string
-                projectEditors:
+                projectViewers:
                   type: array
                   items:
                     type: string
@@ -45,5 +45,5 @@ spec:
                 - folderName
                 - projectName
                 - projectId
-                - projectOwners
                 - projectEditors
+                - projectViewers


### PR DESCRIPTION
- New `projectViewers` and `projectEditors` xrd properties
- IAM roles for project
  - viewers
  - editors 
- Add missing `readinessChecks` for `PROJECT` and `BILLING-IAM`

Sample Claim
---
```yaml
apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
kind: ProjectClaim
metadata:
  name: project-claim
spec:
  rootFolderId: "<folder-id>"
  folderName: project-folder
  projectName: project-name
  projectId: project-id
  projectEditors: 
    - "user:<email>"  
  projectViewers: 
    - "user:<email>"
```