### PR TITLE
Resolve the __dirname problem reported by ESLint

### DIFF
--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -39,7 +39,7 @@ backend:
       repo:
         owner: ${GITOPS_REPO_OWNER}
         name: ${GITOPS_REPO_NAME}
-      templateDir: '../../../../../../templates'
+      templateDir: './templates'
 
 integrations:
   github:

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -22,7 +22,7 @@ const config = mockServices.rootConfig({
             owner: '<repo-owner>',
             name: '<repo-name>',
           },
-          templateDir: '../../../../../../templates',
+          templateDir: './templates',
         },
       },
     },

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -5,6 +5,7 @@ import { Config } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
+import { resolvePackagePath } from '@backstage/backend-common';
 
 const rootFolderId = '108494461414';
 
@@ -20,9 +21,10 @@ export const getConfig = (config: Config): ProvisionerConfig => {
   const rawTemplateDir = config.getString(
     'backend.plugins.provisioner.templateDir',
   );
+  const rootDir = resolvePackagePath('backend', '../../');
   const templateDir = path.isAbsolute(rawTemplateDir)
     ? rawTemplateDir
-    : path.join(__dirname, rawTemplateDir);
+    : path.join(rootDir, rawTemplateDir);
 
   return {
     repo: {

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/__testUtils__/fetchTemplateActionHandler.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/__testUtils__/fetchTemplateActionHandler.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import * as url from 'node:url';
-import { UrlReader } from '@backstage/backend-common';
+import { UrlReader, resolvePackagePath } from '@backstage/backend-common';
 import { MockDirectory } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
 import { createFetchTemplateAction } from '@backstage/plugin-scaffolder-backend';
@@ -12,15 +12,18 @@ export const fetchTemplateActionHandler = ({
   values,
   mockDir,
 }: {
-  namespace?: string,
+  namespace?: string;
   name: string;
   values: any;
   mockDir: MockDirectory;
 }) => {
   // Create the context
+  const rootDir = resolvePackagePath('backend', '../../');
   const templateFilePath = path.join(
-    __dirname,
-    '../../../../../../../templates/', name, 'template.yaml',
+    rootDir,
+    'templates',
+    name,
+    'template.yaml',
   );
   const baseUrl = url.pathToFileURL(templateFilePath).href;
   const ctx = {

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -17,8 +17,8 @@ describe('project-create: fetch:template', () => {
         projectName: '<project-name>',
         projectId: '<project-id>',
       },
-      mockDir
-    })
+      mockDir,
+    });
 
     expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
       {


### PR DESCRIPTION
This PR closes #218.

> [!IMPORTANT]  
> Update the ConfigMap when this is deployed.

--

### Proposed Changes

- Change our `templateDir` setting to be relative to the backstage/ directory.
- Replaced `__dirname` with a path relative to the `backend` module

### Test Plan

Creating a Project with **Diff Only** works as expected.

