### PR TITLE
Enable WI for crossplane terraform provider

### DIFF
--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -71,7 +71,7 @@ resource "google_service_account_iam_member" "iam_workloadidentity_tf" {
   role               = "roles/iam.workloadIdentityUser"
 
   # Workload Identity is specified per-project and per-namespace
-   member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/provider-terraform]"
+  member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/provider-terraform]"
 }
 
 resource "google_project_iam_member" "editor_role" {

--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -66,13 +66,22 @@ resource "google_service_account_iam_member" "iam_workloadidentity_kcc" {
   member = "serviceAccount:${var.project_id}.svc.id.goog[cnrm-system/cnrm-controller-manager]"
 }
 
-resource "google_service_account_iam_member" "iam_workloadidentity_tf" {
+resource "google_service_account_iam_member" "iam_workloadidentity_kcc_sa" {
   service_account_id = google_service_account.phac-backstage-kcc-sa.name
   role               = "roles/iam.workloadIdentityUser"
 
   # Workload Identity is specified per-project and per-namespace
   member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/phac-backstage-kcc-sa]"
 }
+
+# Enable Workload Identity for crossplane terraform provider  
+resource "google_service_account_iam_member" "iam_workloadidentity_tf" {
+  service_account_id = google_service_account.phac-backstage-kcc-sa.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/provider-terraform]"
+}
+
 
 resource "google_project_iam_member" "editor_role" {
   project = var.project_id

--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -66,22 +66,13 @@ resource "google_service_account_iam_member" "iam_workloadidentity_kcc" {
   member = "serviceAccount:${var.project_id}.svc.id.goog[cnrm-system/cnrm-controller-manager]"
 }
 
-resource "google_service_account_iam_member" "iam_workloadidentity_kcc_sa" {
-  service_account_id = google_service_account.phac-backstage-kcc-sa.name
-  role               = "roles/iam.workloadIdentityUser"
-
-  # Workload Identity is specified per-project and per-namespace
-  member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/phac-backstage-kcc-sa]"
-}
-
-# Enable Workload Identity for crossplane terraform provider  
 resource "google_service_account_iam_member" "iam_workloadidentity_tf" {
   service_account_id = google_service_account.phac-backstage-kcc-sa.name
   role               = "roles/iam.workloadIdentityUser"
 
-  member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/provider-terraform]"
+  # Workload Identity is specified per-project and per-namespace
+   member = "serviceAccount:${var.project_id}.svc.id.goog[crossplane-system/provider-terraform]"
 }
-
 
 resource "google_project_iam_member" "editor_role" {
   project = var.project_id


### PR DESCRIPTION
- Enable Workload Identity for crossplane terraform provider

SA used by terraform provider
---
![image](https://github.com/PHACDataHub/sci-portal/assets/48633735/035c05b7-23cc-4c08-9fca-58a1d9795b80)

SA used by kcc
---
![image](https://github.com/PHACDataHub/sci-portal/assets/48633735/38b4ffc4-92f5-46f1-878a-36da2a995f7c)
