### PR TITLE
Update the ULID based on Keith's new 10-character requirement

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -141,7 +141,7 @@ describe('provisioner', () => {
         ### GCP Project
 
         **Project Name:** ph-test-42
-        **Project ID:** phx-01an4z07by7
+        **Project ID:** phx-01an4z07by
         **Data Classification:** Unclassified
 
         ### Administrative Details
@@ -179,7 +179,7 @@ describe('provisioner', () => {
           // Project
           rootFolderId: '108494461414',
           projectName: 'ph-test-42',
-          projectId: 'phx-01an4z07by7',
+          projectId: 'phx-01an4z07by',
 
           // Information Management and Security
           dataClassificationTitle: 'Unclassified',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -52,15 +52,15 @@ const toUser = (ownerEmail: string): User => ({
 });
 
 /**
- * Returns a unique project ID based on the department and part of a ULID.
+ * Returns a unique project ID based on the department and the lowercase timestamp part of a ULID.
  */
 const createProjectId = (department: TemplateParameters['department']) => {
   // All projects are treated as Experimental for now.
   const environment = 'x';
 
-  // The unique ID is based on a ULID. It used the 10-character timestamp part, and one more.
-  // This follows Keith's specification, use in acm-core, and the ulid tool defined in https://github.com/PHACDataHub/rust-tools/tree/main/tools/ulid#building-this-tool-from-a-dockerfile-to-be-used-in-a-container-part-of-multi-stage-build.
-  const id = ulid().substring(0, 11).toLowerCase();
+  // This follows Keith's specification from an email dated 2024-05-14 to use only the 10-character timestamp part of the ULID.
+  // This differs from the implementation of the ulid tool defined in https://github.com/PHACDataHub/rust-tools/tree/main/tools/ulid, and use in other repos.
+  const id = ulid().substring(0, 10).toLowerCase();
 
   return `${department}${environment}-${id}`;
 };


### PR DESCRIPTION
This PR updates #111.

--

### Proposed Changes

- Update to match the new spec:

  > **Keith Young**:
  > Our spec is to use the 10 characters of the timestamp.
