### PR TITLE
Group the Rad Lab templates

### DIFF
--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -90,9 +90,7 @@ costInsights:
       minimumFractionDigits: 3
 
 catalog:
-  import:
-    entityFilename: catalog-info.yaml
-    pullRequestBranchName: backstage-integration
+  readonly: true
   rules:
     - allow: [Component, System, API, Resource, Location]
   locations:
@@ -104,14 +102,6 @@ catalog:
 
     # Resource Provisioner template
     - type: file
-      target: ../../templates/project-create/template.yaml
+      target: ../../templates/catalog-info.yaml
       rules:
-        - allow: [Template]
-    - type: file
-      target: ../../templates/rad-lab-data-science-create/template.yaml
-      rules:
-        - allow: [Template]
-    - type: file
-      target: ../../templates/rad-lab-gen-ai-create/template.yaml
-      rules:
-        - allow: [Template]
+        - allow: [Location, Template]

--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -140,17 +140,20 @@ const routes = (
         <ReportIssue />
       </TechDocsAddons>
     </Route>
-    <Route path="/create" element={
-      <ScaffolderPage
-        groups={[
-          {
-            title: "Rad Lab Modules",
-            filter: entity =>
-              entity?.metadata?.tags?.includes('rad-lab') ?? false,
-          },
-        ]}
-       />
-    } />
+    <Route
+      path="/create"
+      element={
+        <ScaffolderPage
+          groups={[
+            {
+              title: 'Rad Lab Modules',
+              filter: entity =>
+                entity?.metadata?.tags?.includes('rad-lab') ?? false,
+            },
+          ]}
+        />
+      }
+    />
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route
       path="/tech-radar"

--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -140,7 +140,17 @@ const routes = (
         <ReportIssue />
       </TechDocsAddons>
     </Route>
-    <Route path="/create" element={<ScaffolderPage />} />
+    <Route path="/create" element={
+      <ScaffolderPage
+        groups={[
+          {
+            title: "Rad Lab Modules",
+            filter: entity =>
+              entity?.metadata?.tags?.includes('rad-lab') ?? false,
+          },
+        ]}
+       />
+    } />
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route
       path="/tech-radar"

--- a/backstage/templates/add-user/template.yaml
+++ b/backstage/templates/add-user/template.yaml
@@ -5,6 +5,8 @@ metadata:
   name: add-user
   title: Backstage User Template
   description: Create a Backstage User in the [sci-portal-users](https://github.com/PHACDataHub/sci-portal-users) repo.
+  tags:
+    - backstage
 spec:
   owner: platform-team
   type: User

--- a/backstage/templates/catalog-info.yaml
+++ b/backstage/templates/catalog-info.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: templates-google
+  title: Templates - Google
+spec:
+  type: file
+  targets:
+    - ./project-create/template.yaml
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: templates-rad-lab
+  title: Templates - Rad Lab Modules
+spec:
+  type: file
+  targets:
+    - ./rad-lab-data-science-create/template.yaml
+    - ./rad-lab-gen-ai-create/template.yaml
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: templates-backstage
+  title: Templates - Backstage
+spec:
+  type: file
+  targets:
+    - ./add-user/template.yaml

--- a/backstage/templates/rad-lab-data-science-create/template.yaml
+++ b/backstage/templates/rad-lab-data-science-create/template.yaml
@@ -5,6 +5,8 @@ metadata:
   name: rad-lab-data-science-create
   title: RAD Lab Data Science Template
   description: Create a Vertex AI Workbench which hosts sample Jupyter Notebooks as part of data science module deployment. This Project has a budget and budget alerts. The Platform Team will review your request before the Project is created.
+  tags:
+    - rad-lab
 spec:
   owner: platform-team
   type: service

--- a/backstage/templates/rad-lab-gen-ai-create/template.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/template.yaml
@@ -5,6 +5,8 @@ metadata:
   name: rad-lab-gen-ai-create
   title: RAD Lab GenAI Template
   description: Create a Vertex AI Workbench which hosts the contents of the public Google Cloud [Generative AI](https://github.com/GoogleCloudPlatform/generative-ai) repository. The repository contains notebooks and content that demonstrate how to use, develop, and manage generative AI workflows using generative AI, powered by Vertex AI and Generative AI App Builder on Google Cloud. This Project has a budget and budget alerts. The Platform Team will review your request before the Project is created.
+  tags:
+    - rad-lab
 spec:
   owner: platform-team
   type: service


### PR DESCRIPTION
### Proposed Changes

- Enable [readonly mode](https://backstage.io/docs/features/software-catalog/configuration#readonly-mode) to ensure the Catalog references an external source of truth
- Remove the default `catalog-import` configuration
- Build a template index (**templates/catalog-info.yaml**)
- Add a new group for Rad Lab templates to the UI
- Add tags to the templates

### Test Plan

The `Location` entities are added to the Catalog:

<img width="2560" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/b182795a-9360-4613-a54b-3b6f95c72a79">

The templates are grouped:

<img width="2559" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/0e84c3bb-ff83-4951-ab55-fcb5700366e4">
