### PR TITLE
Install gcloud on the provider-terraform image

### DIFF
--- a/bootstrap/crossplane/providers/terraform/bulid/Dockerfile
+++ b/bootstrap/crossplane/providers/terraform/bulid/Dockerfile
@@ -1,0 +1,32 @@
+ARG PROVIDER_TERRAFORM_VERSION=v0.16.0
+FROM xpkg.upbound.io/upbound/provider-terraform:${PROVIDER_TERRAFORM_VERSION}
+
+ARG CLOUD_SDK_VERSION=476.0.0
+ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
+
+# Add the Google Cloud SDK tools to the PATH
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+# Switch back to the root user to install gcloud
+USER root
+RUN if [ `uname -m` = 'x86_64' ]; then ARCH=x86_64; else ARCH=arm; fi; \
+    apk --no-cache upgrade \
+    && apk --no-cache add \
+        curl \
+        python3 \
+        py3-crcmod \
+        py3-openssl \
+        bash \
+        libc6-compat \
+        openssh-client \
+        git \
+        gnupg \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz \
+    && tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz \
+    && rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz \
+    && gcloud config set core/disable_usage_reporting true \
+    && gcloud config set component_manager/disable_update_check true \
+    && gcloud --version
+    
+# Return to the USER from provider-terraform
+USER 65532

--- a/bootstrap/crossplane/providers/terraform/bulid/README.md
+++ b/bootstrap/crossplane/providers/terraform/bulid/README.md
@@ -1,0 +1,37 @@
+This **Dockerfile** extends the Crossplane Terraform Provider image and installs the Google Cloud CLI (`gcloud`).
+
+### Why do we need `gcloud`?
+
+The `gcloud` CLI is required for the [Rad Lab](https://github.com/GoogleCloudPlatform/rad-lab/tree/v13.3.1/modules) modules that call it in a `local-exec` command like [**modules/gen_ai/main.tf**](https://github.com/GoogleCloudPlatform/rad-lab/blob/v13.3.1/modules/gen_ai/main.tf#L181-L188):
+
+```tf
+resource "null_resource" "ai_workbench_usermanaged_provisioning_state" {
+  for_each = toset(google_notebooks_instance.ai_workbench_usermanaged[*].name)
+  provisioner "local-exec" {
+    command = "while [ \"$(gcloud notebooks instances list --location ${var.zone} --project ${local.project.project_id} --filter 'NAME:${each.value} AND STATE:ACTIVE' --format 'value(STATE)' | wc -l | xargs)\" != 1 ]; do echo \"${each.value} not active yet.\"; done"
+  }
+
+  depends_on = [google_notebooks_instance.ai_workbench_usermanaged]
+}
+```
+
+### What is the Crossplane Terraform Provider base image?
+
+The `provider-terraform` image is defined in [the **Dockerfile**](https://github.com/upbound/provider-terraform/blob/main/cluster/images/provider-terraform/Dockerfile) in the `upbound/provider-terraform` repo. It uses Alpine Linux.
+
+### How do we install `gcloud`?
+
+We can follow the [installation instructions](https://cloud.google.com/sdk/docs/install#linux) and Alpine [**Dockerfile**](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile) to install the required dependencies and `gcloud`.
+
+<!-- TODO: Auth -->
+
+### How do we maintain the image?
+
+Set the version of `provider-terraform` and `gcloud` using the build arguments:
+
+```
+docker build \
+  --build-arg=PROVIDER_TERRAFORM_VERSION=v0.15.0 \
+  --build-arg=CLOUD_SDK_VERSION=475.0.0 \
+  .
+```

--- a/bootstrap/crossplane/templates/terrafrom/deployment-runtime-config.yaml
+++ b/bootstrap/crossplane/templates/terrafrom/deployment-runtime-config.yaml
@@ -3,6 +3,20 @@ kind: DeploymentRuntimeConfig
 metadata:
   name: tf-controller-config
 spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          containers:
+            - name: package-runtime
+              image: localhost:5001/provider-terraform:v0.16.0
+              # args:
+              #   - --debug
+              #   # - --timeout=5m
+              # env:
+              #   - name: TF_LOG
+              #     value: INFO
   serviceAccountTemplate:
     metadata:
       name: provider-terraform


### PR DESCRIPTION
### Proposed Changes

- Install `gcloud` on the `provider-terraform` base image

### TODO

- Build the image, push to Artifact Registry, and update the image URL
- Test if `gcloud` will use the Service Account for auth when deployed in the cluster
- Add a Cloud Build trigger to build and push
