### PR TITLE
Add Cloud Build configuration for our provider-terraform image

### DIFF
--- a/backstage/packages/backend/cloudbuild.yaml
+++ b/backstage/packages/backend/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  # Get GitHub App credentials
+  # The build requires the GitHub App credentials to be defined.
   - name: 'ubuntu'
     dir: 'backstage'
     entrypoint: bash
@@ -29,20 +29,20 @@ steps:
   # Build Image
   - name: 'gcr.io/cloud-builders/docker'
     dir: 'backstage'
-    args: ['image','build','.','-f','packages/backend/Dockerfile','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/ph-backstage/backstage:latest','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/ph-backstage/backstage:$SHORT_SHA']
+    args: ['image','build','.','-f','packages/backend/Dockerfile','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:latest','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:$SHORT_SHA']
     env:
       - 'DOCKER_BUILDKIT=1'
 
   # Publish Image
   - name: 'gcr.io/cloud-builders/docker'
     dir: 'backstage'
-    args: ['push', '--all-tags','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/ph-backstage/backstage']
+    args: ['push', '--all-tags','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE']
 
   # Deploy Image to GKE
   - name: "gcr.io/cloud-builders/gke-deploy"
     args:
     - run
-    - --image=$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/ph-backstage/backstage:$SHORT_SHA
+    - --image=$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:$SHORT_SHA
     - --cluster=$_CLUSTER_NAME
     - --location=$_CLUSTER_LOCATION
     - --filename=root-sync/base/backstage/backstage.yaml
@@ -50,5 +50,7 @@ steps:
 substitutions:
   _NPM_IMAGE_TAG: node-18.12.0
   _ARTIFACT_REGISTRY_LOCATION: northamerica-northeast1-docker
+  _ARTIFACT_REGISTRY_REPOSITORY: ph-backstage
+  _ARTIFACT_REGISTRY_IMAGE: backstage
   _CLUSTER_NAME: phac-backstage
   _CLUSTER_LOCATION: northamerica-northeast1

--- a/bootstrap/crossplane/templates/terrafrom/build/cloudbuild.yaml
+++ b/bootstrap/crossplane/templates/terrafrom/build/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+  # Build Image
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'backstage'
+    args: ['image','build','.','--build-arg=PROVIDER_TERRAFORM_VERSION=$_PROVIDER_TERRAFORM_VERSION', '--build-arg=CLOUD_SDK_VERSION=$_CLOUD_SDK_VERSION','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:latest','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:$SHORT_SHA','--tag','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE:$_PROVIDER_TERRAFORM_VERSION']
+    env:
+      - 'DOCKER_BUILDKIT=1'
+
+  # Publish Image
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'backstage'
+    args: ['push', '--all-tags','$_ARTIFACT_REGISTRY_LOCATION.pkg.dev/$PROJECT_ID/$_ARTIFACT_REGISTRY_REPOSITORY/$_ARTIFACT_REGISTRY_IMAGE']
+
+substitutions:
+  _ARTIFACT_REGISTRY_LOCATION: northamerica-northeast1-docker
+  _ARTIFACT_REGISTRY_REPOSITORY: ph-backstage
+  _ARTIFACT_REGISTRY_IMAGE: provider-terraform
+  _PROVIDER_TERRAFORM_VERSION: v0.16.0
+  _CLOUD_SDK_VERSION: 476.0.0

--- a/bootstrap/gke-cluster/main.tf
+++ b/bootstrap/gke-cluster/main.tf
@@ -31,6 +31,19 @@ resource "google_cloudbuild_trigger" "data_science_portal_trigger" {
   filename       = "backstage/packages/backend/cloudbuild.yaml"
 }
 
+resource "google_cloudbuild_trigger" "provider_terraform_trigger" {
+  name     = "proivder-terraform-image-trigger"
+  location = var.cloudbuild_host_connection_region
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.data_science_portal.id
+    push {
+      branch = var.cloudbuild_repository_branch
+    }
+  }
+  included_files = ["bootstrap/crossplane/templates/terrafrom/build/Dockerfile"]
+  filename       = "bootstrap/crossplane/templates/terrafrom/build/cloudbuild.yaml"
+}
+
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-public-cluster"
   version = "~> 30.0"


### PR DESCRIPTION
### Proposed Changes

- Extract the Artifact Registry repo and image as variables
- Create a new Cloud Build configuration for our changes to the `provider-terraform` image
    - Declare the provider-terraform and Cloud SDK versions as substitutions to make it easy to maintain
    - Tag the image with the provider-terraform version
- Add the Terraform to declare the Cloud Build Trigger

### Notes

> [!NOTE]  
> The Cloud Build trigger has already been added [here](https://console.cloud.google.com/cloud-build/triggers;region=northamerica-northeast1/edit/7699b538-8d29-4746-9e83-893e2c5dd676?project=pht-01hsv4d2m0n).
