### PR TITLE
Move groups to sci-portal-users

### DIFF
--- a/backstage/catalog-info.yaml
+++ b/backstage/catalog-info.yaml
@@ -20,24 +20,3 @@ spec:
   type: website
   owner: group:platform-team
   lifecycle: experimental
-
----
-apiVersion: backstage.io/v1alpha1
-kind: Group
-metadata:
-  name: platform-team
-  title: Platform Team
-spec:
-  type: root
-  children:
-    - group:foci
-
----
-apiVersion: backstage.io/v1alpha1
-kind: Group
-metadata:
-  name: foci-team
-  title: Foci Solutions Team
-spec:
-  type: team
-  children: []


### PR DESCRIPTION
This PR is part of #273. The other side of the move is PHACDataHub/sci-portal-users#3.
