### PR TITLE
Fix GenAi Output 

### DIFF
--- a/templates/rad-lab/gen-ai/outputs.tf
+++ b/templates/rad-lab/gen-ai/outputs.tf
@@ -32,7 +32,7 @@ output "workbench_googlemanaged_names" {
 
 output "workbench_googlemanaged_urls" {
   description = "Google Managed Notebook access URLs"
-  value       = formatlist("https://%s", google_notebooks_runtime.ai_workbench_googlemanaged[*].proxy_uri)
+  value       = formatlist("https://console.cloud.google.com/vertex-ai/workbench/managed?project=%s", local.project.project_id)
 }
 
 output "workbench_usermanaged_names" {


### PR DESCRIPTION
- Fix Output 

```
Error: Unsupported attribute

  on outputs.tf line 35, in output "workbench_googlemanaged_urls":
  35:   value       = formatlist("https://%s", google_notebooks_runtime.ai_workbench_googlemanaged[*].proxy_uri)

This object does not have an attribute named "proxy_uri".`

```