### PR TITLE
Add an initial test with Kyverno chainsaw

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,17 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.10.5/.schema/devbox.schema.json",
   "packages": [
+    "crossplane-cli@1.15.2",
     "gh@2.48.0",
     "go-task@3.36.0",
     "k9s@0.32.4",
     "kubeconform@0.6.4",
     "kubectl@1.29.4",
     "kubernetes-helm@3.14.4",
+    "kyverno-chainsaw@0.2.2",
     "shellcheck@0.10.0",
     "terraform@1.7.5",
 
-    "path:./.devbox/flakes/google-cloud-sdk#google-cloud-sdk",
-    "crossplane-cli@1.15.2"
+    "path:./.devbox/flakes/google-cloud-sdk#google-cloud-sdk"
   ],
   "shell": {
     "init_hook": []

--- a/devbox.lock
+++ b/devbox.lock
@@ -373,6 +373,54 @@
         }
       }
     },
+    "kyverno-chainsaw@0.2.2": {
+      "last_modified": "2024-05-23T08:10:22Z",
+      "resolved": "github:NixOS/nixpkgs/3305b2b25e4ae4baee872346eae133cf6f611783#kyverno-chainsaw",
+      "source": "devbox-search",
+      "version": "0.2.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kp5s87v4w2rgds5m3h7dpdga50hwbvnd-kyverno-chainsaw-0.2.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kp5s87v4w2rgds5m3h7dpdga50hwbvnd-kyverno-chainsaw-0.2.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/266dfg0yfvbrzd9zfchcla29f2wdykw1-kyverno-chainsaw-0.2.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/266dfg0yfvbrzd9zfchcla29f2wdykw1-kyverno-chainsaw-0.2.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6xrqy726l3hyg7m2r01gvi8zd367kbn7-kyverno-chainsaw-0.2.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6xrqy726l3hyg7m2r01gvi8zd367kbn7-kyverno-chainsaw-0.2.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/khps06lzhq6r89miakiw8q2hahwaw22w-kyverno-chainsaw-0.2.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/khps06lzhq6r89miakiw8q2hahwaw22w-kyverno-chainsaw-0.2.2"
+        }
+      }
+    },
     "shellcheck@0.10.0": {
       "last_modified": "2024-04-19T17:36:04-04:00",
       "resolved": "github:NixOS/nixpkgs/92d295f588631b0db2da509f381b4fb1e74173c5#shellcheck",

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -219,7 +219,7 @@ spec:
           toFieldPath: "spec.references[0].dependsOn.name"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.projectRef.name"
-        - fromFieldPath: "spec.projectId"
+        - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.metadata.name"
           transforms:
             - type: string

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: project-claim
+spec:
+  # cluster: gke_pht-01hsv4d2m0n_northamerica-northeast1_phac-backstage
+
+  template: true
+  bindings:
+    - name: folderId
+      value: "108494461414"
+    - name: projectNamePrefix
+      value: phx-chainsaw-
+
+    # Generated values
+    - name: requestId
+      value: <uuid>
+    - name: projectId
+      value: phx-<ulid-timestamp>
+    - name: projectName
+      value: phx-chainsaw-###
+
+  steps:
+    - try:
+        - delete:
+            ref:
+              apiVersion: apiextensions.crossplane.io/v1
+              kind: CompositeResourceDefinition
+              name: xprojects.data-science-portal.phac-aspc.gc.ca
+        - apply:
+            file: ../../../root-sync/base/crossplane/project/xrd-project.yaml
+        - description: Assert the CompositeResourceDefinition has been created
+          assert:
+            resource:
+              apiVersion: apiextensions.crossplane.io/v1
+              kind: CompositeResourceDefinition
+              metadata:
+                name: xprojects.data-science-portal.phac-aspc.gc.ca
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
+                (conditions[?type == 'Offered']):
+                  - status: "True"
+
+        - delete:
+            ref:
+              apiVersion: apiextensions.crossplane.io/v1
+              kind: Composition
+              name: project
+        - apply:
+            file: ../../../root-sync/base/crossplane/project/composition-project.yaml
+
+    - try:
+        - description: Generate the request ID
+          script:
+            content: uuidgen | tr '[:upper:]' '[:lower:]'
+            outputs:
+              - name: requestId
+                value: ($stdout)
+
+        - description: Generate the project ID
+          script:
+            content: curl --silent https://ulid.truestamp.com/ | jq -r '.[0].ulid' | tr '[:upper:]' '[:lower:]' | cut -c 1-11
+            outputs:
+              - name: projectId
+                value: (concat('phx-', $stdout))
+
+        - description: Generate the next project name
+          script:
+            content: gcloud projects list --filter 'name:phx-chainsaw-* AND lifecycleState:*' --sort-by=~createTime --limit 1 --format='value(NAME)'
+            outputs:
+              - name: projectName
+                value: (concat($projectNamePrefix, pad_left(to_string(add(to_number(trim_left($stdout, $projectNamePrefix)), `1`)), `3`, '0')))
+
+        - description: Apply a ProjectClaim
+          apply:
+            resource:
+              apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
+              kind: ProjectClaim
+              metadata:
+                namespace: default
+                name: (join('-', [$projectName, $requestId]))
+              spec:
+                rootFolderId: ($folderId)
+                projectName: ($projectName)
+                projectId: ($projectId)
+                projectEditors:
+                  - user:sean.poulter@focisolutions.com
+                projectViewers:
+                  - user:sean.poulter@focisolutions.com
+                  - user:sean.poulter@gcp.hc-sc.gc.ca
+
+        - description: Assert the ProjectClaim has been created
+          assert:
+            resource:
+              apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
+              kind: ProjectClaim
+              metadata:
+                namespace: default
+                name: (join('-', [$projectName, $requestId]))
+              status:
+                (conditions[?type == 'Synced']):
+                  - status: "True"
+                (conditions[?type == 'Ready']):
+                  - status: "True"
+
+        - description: Assert the Project has been created with Config Connector
+          assert:
+            timeout: 2m
+            resource:
+              apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+              kind: Project
+              metadata:
+                namespace: default
+                name: ($projectName)
+                annotations:
+                  cnrm.cloud.google.com/auto-create-network: "false"
+              spec:
+                name: ($projectName)
+                resourceID: ($projectId)
+                folderRef:
+                  external: ($folderId)
+              status:
+                (conditions[?type == 'Ready' && reason == 'UpToDate']):
+                  - status: "True"
+
+        - description: Assert the IAMPolicy has been created with Config Connector
+          assert:
+            resource:
+              apiVersion: iam.cnrm.cloud.google.com/v1beta1
+              kind: IAMPolicy
+              metadata:
+                namespace: default
+                name: (join('-', ['iampolicy', $projectName]))
+              spec:
+                resourceRef:
+                  kind: Project
+                  name: ($projectName)
+                bindings:
+                  - role: roles/editor
+                    members:
+                      - user:sean.poulter@focisolutions.com
+                  - role: roles/viewer
+                    members:
+                      - user:sean.poulter@focisolutions.com
+                      - user:sean.poulter@gcp.hc-sc.gc.ca
+              status:
+                (conditions[?type == 'Ready' && reason == 'UpToDate']):
+                  - status: "True"
+
+        - description: Assert the Budget has been created with Config Connector
+          assert:
+            resource:
+              apiVersion: billingbudgets.cnrm.cloud.google.com/v1beta1
+              kind: BillingBudgetsBudget
+              metadata:
+                namespace: default
+                name: (join('-', ['budget', $projectName]))
+              spec:
+                displayName: (join('-', ['budget', $projectName]))
+                budgetFilter:
+                  projects:
+                    - name: ($projectName)
+
+        - description: Assert the Dataplex API has been enabled with Config Connector
+          assert:
+            resource:
+              apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+              kind: Service
+              metadata:
+                namespace: default
+                name: (join('-', ['dataplex', $projectName]))
+              spec:
+                projectRef:
+                  name: ($projectName)
+                resourceID: dataplex.googleapis.com


### PR DESCRIPTION
### Proposed Changes

- Install `chainsaw`
- Add an initial test for the Project
- Update the Dataplex API naming convention to match the rest

### Usage

Ensure you can list Projects with `gcloud`:

```
$ devbox shell
(devbox) $ gcloud config set account <email-account>@gcp.hc-sc.gc.ca
(devbox) $ gcloud projects list --filter 'name:phx-chainsaw-* AND lifecycleState:*' --sort-by=~createTime --limit 1 --format='value(NAME)'
phx-chainsaw-016
```

Run the tests:

```
(devbox) $ cd tests/
(devbox) $ chainsaw test
```

Run the tests, pausing on failure for development:

```
(devbox) $ cd tests/
(devbox) $ chainsaw test --pause-on-failure
```

### Screenshot / Demo

<img width="1009" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/16cca6ea-cf16-4bc9-a44d-4ab674e90c4b">
