### PR TITLE
Populate the Catalog from GitHub

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -38,6 +38,9 @@ backend:
       templateDir: '/app/templates'
 
 catalog:
+  readonly: true
+  rules:
+    - allow: [Component, System, API, Resource, Location, User, Group]
   locations:
     # Backstage entities
     - type: file
@@ -47,17 +50,33 @@ catalog:
 
     # Resource Provisioner template
     - type: file
-      target: /app/templates/project-create/template.yaml
+      target: /app/templates/catalog-info.yaml
       rules:
-        - allow: [Template]
-    - type: file
-      target: /app/templates/rad-lab-data-science-create/template.yaml
-      rules:
-        - allow: [Template]
-    - type: file
-      target: /app/templates/rad-lab-gen-ai-create/template.yaml
-      rules:
-        - allow: [Template]
+        - allow: [Location, Template]
+
+  providers:
+    github:
+      # Load Users and Groups from the sci-portal-users repo.
+      sci-portal-users:
+        organization: 'PHACDataHub'
+        filters:
+          repository: '^sci-portal-users$'
+          branch: 'main'
+        catalogPath: '/**/*.yaml'
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+
+      # Load Components and Resources from part of the sci-portal repo.
+      sci-portal:
+        organization: 'PHACDataHub'
+        filters:
+          repository: '^sci-portal$'
+          branch: 'main'
+        catalogPath: '/DMIA-PHAC/**/catalog-info.yaml'
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
 
 kubernetes:
   serviceLocatorMethod:

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -78,7 +78,7 @@ enableExperimentalRedirectFlow: true
 catalog:
   readonly: true
   rules:
-    - allow: [Component, System, API, Resource, Location]
+    - allow: [Component, System, API, Resource, Location, User, Group]
   locations:
     # Backstage entities
     - type: file
@@ -91,3 +91,27 @@ catalog:
       target: ../../templates/catalog-info.yaml
       rules:
         - allow: [Location, Template]
+
+  providers:
+    github:
+      # Load Users and Groups from the sci-portal-users repo.
+      sci-portal-users:
+        organization: 'PHACDataHub'
+        filters:
+          repository: '^sci-portal-users$'
+          branch: 'main'
+        catalogPath: '/**/*.yaml'
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+
+      # Load Components and Resources from part of the sci-portal repo.
+      sci-portal:
+        organization: 'PHACDataHub'
+        filters:
+          repository: '^sci-portal$'
+          branch: 'main'
+        catalogPath: '/DMIA-PHAC/**/catalog-info.yaml'
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }

--- a/backstage/packages/backend/package.json
+++ b/backstage/packages/backend/package.json
@@ -29,6 +29,7 @@
     "@backstage/plugin-auth-backend-module-google-provider": "^0.1.15",
     "@backstage/plugin-auth-node": "^0.4.13",
     "@backstage/plugin-catalog-backend": "^1.22.0",
+    "@backstage/plugin-catalog-backend-module-github": "^0.6.1",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "^0.1.16",
     "@backstage/plugin-permission-backend": "^0.5.42",
     "@backstage/plugin-permission-backend-module-allow-all-policy": "^0.1.15",

--- a/backstage/packages/backend/src/index.ts
+++ b/backstage/packages/backend/src/index.ts
@@ -20,6 +20,7 @@ backend.add(googleAuthWithCustomSignInResolver);
 
 // catalog plugin
 backend.add(import('@backstage/plugin-catalog-backend/alpha'));
+backend.add(import('@backstage/plugin-catalog-backend-module-github/alpha'));
 backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );

--- a/backstage/yarn.lock
+++ b/backstage/yarn.lock
@@ -3286,6 +3286,30 @@
     "@react-hookz/web" "^24.0.0"
     "@types/react" "^16.13.1 || ^17.0.0 || ^18.0.0"
 
+"@backstage/plugin-catalog-backend-module-github@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-backend-module-github/-/plugin-catalog-backend-module-github-0.6.1.tgz#6d538fa698b436b9f8699e56c22d7f79be40bce1"
+  integrity sha512-neuK4zpWbqALDGSmdyTL4L8vWsXLi+lFtit00wDaC0LqeHZcRYW3Np8ebbVkCx3vyvYuEcOOlBpt+BsirVnAYw==
+  dependencies:
+    "@backstage/backend-common" "^0.22.0"
+    "@backstage/backend-plugin-api" "^0.6.18"
+    "@backstage/backend-tasks" "^0.5.23"
+    "@backstage/catalog-client" "^1.6.5"
+    "@backstage/catalog-model" "^1.5.0"
+    "@backstage/config" "^1.2.0"
+    "@backstage/integration" "^1.11.0"
+    "@backstage/plugin-catalog-backend" "^1.22.0"
+    "@backstage/plugin-catalog-common" "^1.0.23"
+    "@backstage/plugin-catalog-node" "^1.12.0"
+    "@backstage/plugin-events-node" "^0.3.4"
+    "@octokit/graphql" "^5.0.0"
+    "@octokit/rest" "^19.0.3"
+    git-url-parse "^14.0.0"
+    lodash "^4.17.21"
+    minimatch "^9.0.0"
+    node-fetch "^2.6.7"
+    uuid "^9.0.0"
+
 "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@^0.1.16":
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-backend-module-scaffolder-entity-model/-/plugin-catalog-backend-module-scaffolder-entity-model-0.1.16.tgz#0fe6a89a46fe8800e016a194d52c5fec7f3c7700"
@@ -9347,7 +9371,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -9378,12 +9402,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
-  version "18.3.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.2.tgz#462ae4904973bc212fa910424d901e3d137dbfcd"
-  integrity sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
+  version "18.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
+  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.13.1 || ^17.0.0":
+  version "17.0.80"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
+  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/request@^2.47.1", "@types/request@^2.48.8":
@@ -9417,6 +9450,11 @@
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.7.tgz#dab4d16ba7568e9846c454a8764f33c5d98e5524"
   integrity sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==
+
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"


### PR DESCRIPTION
This PR depends on #296. The PR closes #288.

### Proposed Changes

- Load `User`s and `Group`s from the **sci-portal-users** repo
- Load entities from the **DMIA-PHAC/** folder

### Screenshots/Demo

You can see we've added two `Location`s to the Catalog from GitHub:

<img width="2056" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/8f9e96b7-cb9f-47d3-a9d0-7659ece3ee50">

### Notes

This uses polling. Configure setting up event support (webhooks) to use a push-based model. https://backstage.io/docs/integrations/github/discovery/#events-support
