### PR TITLE
refactor: Reorganize to group by use case

### DIFF
--- a/backstage/packages/backend/src/plugins/auth/module.ts
+++ b/backstage/packages/backend/src/plugins/auth/module.ts
@@ -43,17 +43,13 @@ export const googleAuthWithCustomSignInResolver = createBackendModule({
               }
 
               // Sign in with the user from the Catalog if possible
-              const catalogQuery = {
-                filter: {
-                  kind: ['User'],
-                  namespace: domain,
-                  name,
-                },
+              const entityFilterQuery = {
+                filter: [{ kind: 'User', 'spec.profile.email': profile.email }],
               };
               try {
-                const { entity } = await ctx.findCatalogUser(catalogQuery);
+                const { entity } = await ctx.findCatalogUser(entityFilterQuery);
                 if (entity) {
-                  return ctx.signInWithCatalogUser(catalogQuery);
+                  return ctx.signInWithCatalogUser(entityFilterQuery);
                 }
               } catch (err) {
                 if (!(err instanceof NotFoundError)) {


### PR DESCRIPTION
This PR depends on #303.

### Proposed Changes

- Rename `templateContext` as `templateValues` to match the output
- Move the Nunjucks setup closer to where it is used
- Move the PR title `ctx.output` call closer to the assignment
