### PR TITLE
Include the current user in the PR

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/getContextActionHandler.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/getContextActionHandler.ts
@@ -26,35 +26,42 @@ export const getContextActionHandler = async ({
   template: { namespace = 'default', name, title },
   config = rootConfig,
   parameters,
+  user,
   mockDir,
 }: {
   template: { namespace?: string; name: string; title?: string };
   parameters?: any;
   config?: RootConfigService;
+  user?: ActionContext<JsonObject>['user'];
   mockDir: MockDirectory;
 }): Promise<{
   ctx: ActionContext<JsonObject> & { getOutput: (name: string) => any };
 }> => {
   const action = createProvisionTemplateAction(config);
-  const ctx = createMockActionContext({
-    input: {
-      parameters: {
-        ...projectParameters,
-        ...parameters,
-      },
-    },
-    templateInfo: {
-      entity: {
-        metadata: {
-          namespace,
-          name,
-          title,
+  const ctx = {
+    ...createMockActionContext({
+      input: {
+        parameters: {
+          ...projectParameters,
+          ...parameters,
         },
       },
-      entityRef: `template:${namespace}/${name}`,
-    },
-    workspacePath: mockDir.resolve('workspace'),
-  });
+      templateInfo: {
+        entity: {
+          metadata: {
+            namespace,
+            name,
+            title,
+          },
+        },
+        entityRef: `template:${namespace}/${name}`,
+      },
+      workspacePath: mockDir.resolve('workspace'),
+    }),
+
+    // The user is not passed through as of v1.27.3 - https://github.com/backstage/backstage/blob/fe4b090b6f5c38b38fc282be3384efcce4423c7d/plugins/scaffolder-node-test-utils/src/actions/mockActionConext.ts#L32-L33.
+    user,
+  };
 
   await action.handler(ctx);
 

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -143,6 +143,14 @@ describe('provisioner', () => {
 
           additionalProperty: 'OK',
         },
+        user: {
+          entity: {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'User',
+            metadata: { name: '' },
+            spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
+          },
+        },
         mockDir,
       });
 
@@ -161,6 +169,7 @@ describe('provisioner', () => {
 
         // Metadata
         requestId: '6bedd76d-4259-44dd-81d1-1052cfd3fed3',
+        requestEmail: 'jane.doe@gcp.hc-sc.gc.ca',
 
         // Project
         rootFolderId: '108494461414',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -248,6 +248,8 @@ export const createProvisionTemplateAction = (config: Config) => {
 
         // Metadata
         requestId,
+        requestEmail:
+          ctx?.user?.entity?.spec?.profile?.email ?? ctx?.user?.ref ?? '',
 
         // Project
         rootFolderId,
@@ -271,7 +273,7 @@ export const createProvisionTemplateAction = (config: Config) => {
         editors: parseEmailInput(ctx.input.parameters.editors).map(toUser),
       };
       ctx.output('template_values', templateValues);
-    
+
       // Set the Pull Request title
       const templateTitle =
         ctx.templateInfo.entity.metadata.title ||

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -38,13 +38,22 @@ describe('project-create: fetch:template', () => {
       parameters: {
         ...projectParameters,
       },
+      user: {
+        entity: {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'User',
+          metadata: { name: '' },
+          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
+        },
+      },
       mockDir,
     });
 
     expect(ctx.getOutput('pr_description')).toMatchInlineSnapshot(`
-      "This PR was created using Backstage. The request ID is \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`.
+      "This PR was created using Backstage.
 
-      <!-- ### Client Name Email address -->
+      **Request ID:** \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`
+      **Requested By:** jane.doe@gcp.hc-sc.gc.ca
 
       ### GCP Project
 

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -24,13 +24,22 @@ describe('rad-lab-data-science-create: fetch:template', () => {
         ...projectParameters,
         machineSize: 'Medium',
       },
+      user: {
+        entity: {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'User',
+          metadata: { name: '' },
+          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
+        },
+      },
       mockDir,
     });
 
     expect(ctx.getOutput('pr_description')).toMatchInlineSnapshot(`
-      "This PR was created using Backstage. The request ID is \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`.
-
-      <!-- ### Client Name Email address -->
+      "This PR was created using Backstage.
+      
+      **Request ID:** \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`
+      **Requested By:** jane.doe@gcp.hc-sc.gc.ca
 
       ### GCP Project
 

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -24,13 +24,22 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
         ...projectParameters,
         machineSize: 'Medium',
       },
+      user: {
+        entity: {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'User',
+          metadata: { name: '' },
+          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
+        },
+      },
       mockDir,
     });
 
     expect(ctx.getOutput('pr_description')).toMatchInlineSnapshot(`
-      "This PR was created using Backstage. The request ID is \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`.
+      "This PR was created using Backstage.
 
-      <!-- ### Client Name Email address -->
+      **Request ID:** \`6bedd76d-4259-44dd-81d1-1052cfd3fed3\`
+      **Requested By:** jane.doe@gcp.hc-sc.gc.ca
 
       ### GCP Project
 

--- a/backstage/templates/project-create/pull-request-description.njk
+++ b/backstage/templates/project-create/pull-request-description.njk
@@ -1,6 +1,7 @@
-This PR was created using Backstage. The request ID is `{{requestId}}`.
+This PR was created using Backstage.
 
-<!-- ### Client Name Email address -->
+**Request ID:** `{{requestId}}`
+**Requested By:** {{requestEmail}}
 
 ### GCP Project
 


### PR DESCRIPTION
This PR depends on #304. This PR closes #305.

### Proposed Changes

- Include the current user's email address in the PR. If the email address is not available because the `User` is not in the catalog, you'll see a `ref` like `user:default/sean.poulter`.

### Screenshots / Demo

This is from #306:

<img width="1318" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/044e805d-c08b-45f8-9ad7-f1290d7e76fe">
