### PR TITLE
Enable permissions and restrict access to "template-developer" features

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -103,3 +103,6 @@ auth:
 
 # Sign in without a pop-up. See https://backstage.io/docs/auth/#sign-in-configuration.
 enableExperimentalRedirectFlow: true
+
+permission:
+  enabled: true

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -115,3 +115,6 @@ catalog:
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }
+
+permission:
+  enabled: true

--- a/backstage/packages/backend/package.json
+++ b/backstage/packages/backend/package.json
@@ -38,6 +38,7 @@
     "@backstage/plugin-proxy-backend": "^0.4.16",
     "@backstage/plugin-scaffolder-backend": "^1.22.7",
     "@backstage/plugin-scaffolder-backend-module-github": "^0.2.8",
+    "@backstage/plugin-scaffolder-common": "^1.5.2",
     "@backstage/plugin-scaffolder-node": "^0.4.4",
     "@backstage/plugin-search-backend": "^1.5.9",
     "@backstage/plugin-search-backend-module-catalog": "^0.1.24",

--- a/backstage/packages/backend/src/plugins/permissions/README.md
+++ b/backstage/packages/backend/src/plugins/permissions/README.md
@@ -1,0 +1,4 @@
+This directory declares the permission policies used to authorize interactions with Backstage.
+
+> [!IMPORTANT]  
+> As of May 2024 the Backstage documentation for [Permissions](https://backstage.io/docs/permissions/getting-started) has not been updated for the new backend system. We've referred to the [Migration Guide](https://backstage.io/docs/backend-system/building-backends/migrating/#the-permission-plugin) to set up the Permission plugin for the new backend system.

--- a/backstage/packages/backend/src/plugins/permissions/index.ts
+++ b/backstage/packages/backend/src/plugins/permissions/index.ts
@@ -1,0 +1,45 @@
+import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
+import {
+  AuthorizeResult,
+  PolicyDecision,
+  isPermission,
+} from '@backstage/plugin-permission-common';
+import {
+  PermissionPolicy,
+  PolicyQuery,
+} from '@backstage/plugin-permission-node';
+import {
+  createScaffolderTemplateConditionalDecision,
+  scaffolderTemplateConditions,
+} from '@backstage/plugin-scaffolder-backend/alpha';
+import {
+  templateParameterReadPermission,
+  templateStepReadPermission,
+} from '@backstage/plugin-scaffolder-common/alpha';
+
+const isNotMemberOfPlatformTeam = (user?: BackstageIdentityResponse) =>
+  !(
+    user &&
+    user.identity.ownershipEntityRefs.includes('group:default/platform-team')
+  );
+
+export class CustomPermissionPolicy implements PermissionPolicy {
+  async handle(
+    request: PolicyQuery,
+    user?: BackstageIdentityResponse,
+  ): Promise<PolicyDecision> {
+    if (
+      isNotMemberOfPlatformTeam(user) &&
+      (isPermission(request.permission, templateParameterReadPermission) ||
+        isPermission(request.permission, templateStepReadPermission))
+    ) {
+      return createScaffolderTemplateConditionalDecision(request.permission, {
+        not: scaffolderTemplateConditions.hasTag({ tag: 'template-developer' }),
+      });
+    }
+
+    return {
+      result: AuthorizeResult.ALLOW,
+    };
+  }
+}

--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/createUser.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/createUser.ts
@@ -1,0 +1,17 @@
+import { ActionContext } from '@backstage/plugin-scaffolder-node';
+import { JsonObject } from '@backstage/types';
+
+export const createUser = ({
+  name = '',
+  email,
+}: {
+  name?: string;
+  email: string;
+}): ActionContext<JsonObject>['user'] => ({
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: { name },
+    spec: { profile: { email } },
+  },
+});

--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/createUser.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/createUser.ts
@@ -2,16 +2,22 @@ import { ActionContext } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 
 export const createUser = ({
+  namespace,
   name = '',
   email,
 }: {
+  namespace?: string;
   name?: string;
   email: string;
 }): ActionContext<JsonObject>['user'] => ({
   entity: {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'User',
-    metadata: { name },
+    metadata: {
+      namespace,
+      name,
+    },
     spec: { profile: { email } },
   },
+  ref: `user:${namespace || 'default'}/${name}`,
 });

--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/fetchTemplateActionHandler.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/fetchTemplateActionHandler.ts
@@ -16,7 +16,10 @@ export const fetchTemplateActionHandler = ({
   mockDir: MockDirectory;
 }) => {
   // Create the context
-  const templateFilePath = resolvePackagePath('backend', `../../templates/${name}/template.yaml`);
+  const templateFilePath = resolvePackagePath(
+    'backend',
+    `../../templates/${name}/template.yaml`,
+  );
   const baseUrl = url.pathToFileURL(templateFilePath).href;
   const ctx = {
     ...createMockActionContext({

--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/skip.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/skip.ts
@@ -1,4 +1,5 @@
 /**
  * Skip tests on a given platform
  */
-export const skip = (platform: NodeJS.Platform) => process.platform === platform ? it.skip : it;
+export const skip = (platform: NodeJS.Platform) =>
+  process.platform === platform ? it.skip : it;

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -136,7 +136,7 @@ describe('provisioner', () => {
           budgetAmount: 12345,
           budgetAlertEmailRecipients:
             'samantha.jones@phac-aspc.gc.ca, alex.mcdonald@phac-aspc.gc.ca',
-          owners:
+          editors:
             '   ,,, , jeanne.smith@phac-aspc.gc.ca,karen.schumacher@phac-aspc.gc.ca,,',
           viewers:
             ' samantha.jones@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca',
@@ -185,7 +185,7 @@ describe('provisioner', () => {
         ],
 
         // Permissions
-        owners: [
+        editors: [
           { name: 'jeanne.smith', email: 'jeanne.smith@phac-aspc.gc.ca' },
           {
             name: 'karen.schumacher',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -122,6 +122,17 @@ describe('provisioner', () => {
       expect(typeof ctx.getOutput('pr_description')).toBe('string');
     });
 
+    it('should set the pull request target path', async () => {
+      const { ctx } = await getContextActionHandler({
+        template: { name: 'project-create' },
+        mockDir,
+      });
+
+      expect(ctx.getOutput('pr_targetPath')).toBe(
+        'DMIA-PHAC/SciencePlatform/phx-01an4z07by7',
+      );
+    });
+
     it('should set the template values in the output', async () => {
       const { ctx } = await getContextActionHandler({
         template: { name: 'project-create' },
@@ -144,7 +155,10 @@ describe('provisioner', () => {
 
           additionalProperty: 'OK',
         },
-        user: createUser({ email: 'jane.doe@gcp.hc-sc.gc.ca' }),
+        user: createUser({
+          name: 'jane.doe',
+          email: 'jane.doe@gcp.hc-sc.gc.ca',
+        }),
         mockDir,
       });
 
@@ -174,12 +188,14 @@ describe('provisioner', () => {
         // Budget
         formattedBudgetAmount: '$12,345',
         budgetAlertEmailRecipients: [
+          'jane.doe@gcp.hc-sc.gc.ca',
           'samantha.jones@phac-aspc.gc.ca',
           'alex.mcdonald@phac-aspc.gc.ca',
         ],
 
         // Permissions
         editors: [
+          { name: 'jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
           { name: 'jeanne.smith', email: 'jeanne.smith@phac-aspc.gc.ca' },
           {
             name: 'karen.schumacher',
@@ -190,6 +206,9 @@ describe('provisioner', () => {
           { name: 'samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
           { name: 'john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
         ],
+
+        // Backstage
+        catalogEntityOwner: 'user:default/jane.doe',
 
         // Additional properties that are not in the input schema are included in the output.
         additionalProperty: 'OK',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -138,7 +138,7 @@ describe('provisioner', () => {
             'samantha.jones@phac-aspc.gc.ca, alex.mcdonald@phac-aspc.gc.ca',
           owners:
             '   ,,, , jeanne.smith@phac-aspc.gc.ca,karen.schumacher@phac-aspc.gc.ca,,',
-          editors:
+          viewers:
             ' samantha.jones@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca',
 
           additionalProperty: 'OK',
@@ -192,7 +192,7 @@ describe('provisioner', () => {
             email: 'karen.schumacher@phac-aspc.gc.ca',
           },
         ],
-        editors: [
+        viewers: [
           { name: 'samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
           { name: 'john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
         ],

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -129,7 +129,7 @@ describe('provisioner', () => {
       });
 
       expect(ctx.getOutput('pr_targetPath')).toBe(
-        'DMIA-PHAC/SciencePlatform/phx-01an4z07by7',
+        'DMIA-PHAC/SciencePlatform/phx-01an4z07by7/',
       );
     });
 
@@ -209,6 +209,7 @@ describe('provisioner', () => {
 
         // Backstage
         catalogEntityOwner: 'user:default/jane.doe',
+        sourceLocation: 'DMIA-PHAC/SciencePlatform/hcx-01an4z07by7/',
 
         // Additional properties that are not in the input schema are included in the output.
         additionalProperty: 'OK',

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -183,6 +183,9 @@ describe('provisioner', () => {
         rootFolderId: '108494461414',
         projectName: 'hcx-test-case',
         projectId: 'hcx-01an4z07by7',
+        projectLabels: {
+          'cost-centre': 'jbu987654321',
+        },
         dataClassificationTitle: 'Protected B',
 
         // Budget

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -3,6 +3,7 @@ import {
   mockServices,
 } from '@backstage/backend-test-utils';
 import { getConfig, parseEmailInput } from './provisioner';
+import { createUser } from '../__testUtils__/createUser';
 import { getContextActionHandler } from '../__testUtils__/getContextActionHandler';
 
 jest.mock('ulidx', () => ({
@@ -143,14 +144,7 @@ describe('provisioner', () => {
 
           additionalProperty: 'OK',
         },
-        user: {
-          entity: {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'User',
-            metadata: { name: '' },
-            spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
-          },
-        },
+        user: createUser({ email: 'jane.doe@gcp.hc-sc.gc.ca' }),
         mockDir,
       });
 

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -185,6 +185,7 @@ describe('provisioner', () => {
         projectId: 'hcx-01an4z07by7',
         projectLabels: {
           'cost-centre': 'jbu987654321',
+          'vanity-name': 'hcx-test-case',
         },
         dataClassificationTitle: 'Protected B',
 

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -100,7 +100,7 @@ interface TemplateParameters extends JsonObject {
   department: 'hc' | 'ph';
   dataClassification: 'UCLL' | 'PBMM';
   vanityName: string;
-  owners?: string;
+  editors?: string;
   viewers?: string;
 
   // Administration
@@ -161,10 +161,10 @@ export const createProvisionTemplateAction = (config: Config) => {
                 minLength: 1,
                 maxLength: 26,
               },
-              owners: {
-                title: 'Owners',
+              editors: {
+                title: 'Editors',
                 description:
-                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.',
+                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by a comma.',
                 type: 'string',
               },
               viewers: {
@@ -269,7 +269,7 @@ export const createProvisionTemplateAction = (config: Config) => {
         ),
 
         // Permissions
-        owners: parseEmailInput(ctx.input.parameters.owners).map(toUser),
+        editors: parseEmailInput(ctx.input.parameters.editors).map(toUser),
         viewers: parseEmailInput(ctx.input.parameters.viewers).map(toUser),
 
         // Backstage

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -268,6 +268,9 @@ export const createProvisionTemplateAction = (config: Config) => {
         rootFolderId,
         projectName,
         projectId,
+        projectLabels: {
+          'cost-centre': ctx.input.parameters.costCentre.toLowerCase(),
+        },
 
         // Information Management and Security
         dataClassificationTitle:

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -270,6 +270,7 @@ export const createProvisionTemplateAction = (config: Config) => {
         projectId,
         projectLabels: {
           'cost-centre': ctx.input.parameters.costCentre.toLowerCase(),
+          'vanity-name': projectName.toLowerCase(),
         },
 
         // Information Management and Security

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -253,6 +253,8 @@ export const createProvisionTemplateAction = (config: Config) => {
         editors.unshift({ email, name: ctx.user?.entity?.metadata.name! });
       }
 
+      const pullRequestTargetPath = `DMIA-PHAC/SciencePlatform/${projectId}/`;
+
       // Populate the template values
       const templateValues = {
         ...ctx.input.parameters,
@@ -283,6 +285,7 @@ export const createProvisionTemplateAction = (config: Config) => {
 
         // Backstage
         catalogEntityOwner: ctx.user?.ref,
+        sourceLocation: pullRequestTargetPath,
       };
       ctx.output('template_values', templateValues);
 
@@ -316,7 +319,7 @@ export const createProvisionTemplateAction = (config: Config) => {
         templateValues,
       );
       ctx.output('pr_description', pullRequestDescription);
-      ctx.output('pr_targetPath', `DMIA-PHAC/SciencePlatform/${projectId}`);
+      ctx.output('pr_targetPath', pullRequestTargetPath);
     },
   });
 };

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -101,7 +101,7 @@ interface TemplateParameters extends JsonObject {
   dataClassification: 'UCLL' | 'PBMM';
   vanityName: string;
   owners?: string;
-  editors?: string;
+  viewers?: string;
 
   // Administration
   costCentre: string;
@@ -164,13 +164,13 @@ export const createProvisionTemplateAction = (config: Config) => {
               owners: {
                 title: 'Owners',
                 description:
-                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by comma.',
+                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.',
                 type: 'string',
               },
-              editors: {
-                title: 'Editors',
+              viewers: {
+                title: 'Viewers',
                 description:
-                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by comma.',
+                  'The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to view this service, separated by a comma.',
                 type: 'string',
               },
 
@@ -270,7 +270,7 @@ export const createProvisionTemplateAction = (config: Config) => {
 
         // Permissions
         owners: parseEmailInput(ctx.input.parameters.owners).map(toUser),
-        editors: parseEmailInput(ctx.input.parameters.editors).map(toUser),
+        viewers: parseEmailInput(ctx.input.parameters.viewers).map(toUser),
 
         // Backstage
         catalogEntityOwner: ctx.user?.ref,

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -15,7 +15,7 @@ export const projectParameters = {
   department: 'ph' as const,
   dataClassification: 'UCLL' as const,
   vanityName: 'test-42',
-  editors: 'jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca',
+  editors: 'john.doe@gcp.hc-sc.gc.ca',
   viewers:
     'samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca',
   costCentre: 'ABC123456789',
@@ -24,7 +24,7 @@ export const projectParameters = {
   justification: 'This project will be used for testing our custom action.',
   budgetAmount: 2_000,
   budgetAlertEmailRecipients:
-    'jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca, steve.smith@gcp.hc-sc.gc.ca',
+    'john.doe@gcp.hc-sc.gc.ca, steve.smith@gcp.hc-sc.gc.ca',
 };
 
 describe('project-create: fetch:template', () => {

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -83,6 +83,9 @@ describe('project-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
+          projectLabels: {
+            'cost-centre': '<cost-centre>',
+          },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
@@ -92,7 +95,6 @@ describe('project-create: fetch:template', () => {
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },
           ],
-          costCentre: 'ABC123456789',
           catalogEntityOwner: 'user:default/jane.doe',
           sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
         },
@@ -132,7 +134,7 @@ describe('project-create: fetch:template', () => {
           - user:alex.mcdonald@gcp.hc-sc.gc.ca
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
-          cost-centre: abc123456789
+          cost-centre: '<cost-centre>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -1,6 +1,7 @@
 import { createMockDirectory } from '@backstage/backend-test-utils';
 import { fetchTemplateActionHandler } from '../__testUtils__/fetchTemplateActionHandler';
 import { getContextActionHandler } from '../__testUtils__/getContextActionHandler';
+import { createUser } from '../__testUtils__/createUser';
 import { skip } from '../__testUtils__/skip';
 
 jest.mock('ulidx', () => ({
@@ -39,14 +40,7 @@ describe('project-create: fetch:template', () => {
       parameters: {
         ...projectParameters,
       },
-      user: {
-        entity: {
-          apiVersion: 'backstage.io/v1alpha1',
-          kind: 'User',
-          metadata: { name: '' },
-          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
-        },
-      },
+      user: createUser({ email: 'jane.doe@gcp.hc-sc.gc.ca' }),
       mockDir,
     });
 

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -15,7 +15,7 @@ export const projectParameters = {
   dataClassification: 'UCLL' as const,
   vanityName: 'test-42',
   owners: 'jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca',
-  editors:
+  viewers:
     'samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca',
   costCentre: 'ABC123456789',
   costCentreName: 'TPS Reports',
@@ -69,7 +69,7 @@ describe('project-create: fetch:template', () => {
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
       **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
-      **Editors:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
+      **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
 
@@ -93,7 +93,7 @@ describe('project-create: fetch:template', () => {
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],
-          editors: [
+          viewers: [
             { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -85,6 +85,7 @@ describe('project-create: fetch:template', () => {
           projectId: '<project-id>',
           projectLabels: {
             'cost-centre': '<cost-centre>',
+            'vanity-name': '<project-name>',
           },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
@@ -135,6 +136,7 @@ describe('project-create: fetch:template', () => {
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
           cost-centre: '<cost-centre>'
+          vanity-name: '<project-name>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -79,31 +79,33 @@ describe('project-create: fetch:template', () => {
     `);
   });
 
-  skip('win32')('The fetch:template action should render the expected changes for the Pull Request', async () => {
-    await fetchTemplateActionHandler({
-      template: { name: 'project-create' },
-      values: {
-        requestId: '<uuid>',
-        rootFolderId: '<root-folder-id>',
-        projectName: '<project-name>',
-        projectId: '<project-id>',
-        owners: [
-          { email: 'jane.doe@gcp.hc-sc.gc.ca' },
-          { email: 'john.doe@gcp.hc-sc.gc.ca' },
-        ],
-        editors: [
-          { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-          { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-          { email: 'john.campbell@gcp.hc-sc.gc.ca' },
-        ],
-        costCentre: 'ABC123456789',
-        pr_targetPath: 'DMIA-PHAC/SciencePlatform/<project-name>',
-        catalogEntityOwner: 'user:default/jane.doe',
-      },
-      mockDir,
-    });
+  skip('win32')(
+    'The fetch:template action should render the expected changes for the Pull Request',
+    async () => {
+      await fetchTemplateActionHandler({
+        template: { name: 'project-create' },
+        values: {
+          requestId: '<uuid>',
+          rootFolderId: '<root-folder-id>',
+          projectName: '<project-name>',
+          projectId: '<project-id>',
+          owners: [
+            { email: 'jane.doe@gcp.hc-sc.gc.ca' },
+            { email: 'john.doe@gcp.hc-sc.gc.ca' },
+          ],
+          editors: [
+            { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+            { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+            { email: 'john.campbell@gcp.hc-sc.gc.ca' },
+          ],
+          costCentre: 'ABC123456789',
+          pr_targetPath: 'DMIA-PHAC/SciencePlatform/<project-name>',
+          catalogEntityOwner: 'user:default/jane.doe',
+        },
+        mockDir,
+      });
 
-    expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
+      expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
       {
         "catalog-info.yaml": "---
       apiVersion: backstage.io/v1alpha1
@@ -140,5 +142,6 @@ describe('project-create: fetch:template', () => {
       ",
       }
     `);
-  });
+    },
+  );
 });

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -93,8 +93,8 @@ describe('project-create: fetch:template', () => {
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },
           ],
           costCentre: 'ABC123456789',
-          pr_targetPath: 'DMIA-PHAC/SciencePlatform/<project-name>',
           catalogEntityOwner: 'user:default/jane.doe',
+          sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
         },
         mockDir,
       });
@@ -108,7 +108,7 @@ describe('project-create: fetch:template', () => {
         name: <project-id>
         title: <project-name>
         annotations:
-          backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/DMIA-PHAC/SciencePlatform/<project-name>/
+          backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/DMIA-PHAC/SciencePlatform/<project-id>/
           backstage.io/source-template: template:default/project-create
           cloud.google.com/project: <project-id>
       spec:

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -14,7 +14,7 @@ export const projectParameters = {
   department: 'ph' as const,
   dataClassification: 'UCLL' as const,
   vanityName: 'test-42',
-  owners: 'jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca',
+  editors: 'jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca',
   viewers:
     'samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca',
   costCentre: 'ABC123456789',
@@ -68,7 +68,7 @@ describe('project-create: fetch:template', () => {
       **Cost Centre Name:** TPS Reports
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
-      **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
+      **Editors:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
       **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
@@ -89,7 +89,7 @@ describe('project-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
-          owners: [
+          editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -73,6 +73,9 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
+          projectLabels: {
+            'cost-centre': '<cost-centre>',
+          },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
@@ -82,7 +85,6 @@ describe('rad-lab-data-science-create: fetch:template', () => {
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },
           ],
-          costCentre: 'ABC123456789',
           catalogEntityOwner: 'user:default/jane.doe',
         },
         mockDir,
@@ -107,7 +109,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           - user:alex.mcdonald@gcp.hc-sc.gc.ca
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
-          cost-centre: abc123456789
+          cost-centre: '<cost-centre>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -75,6 +75,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           projectId: '<project-id>',
           projectLabels: {
             'cost-centre': '<cost-centre>',
+            'vanity-name': '<project-name>',
           },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
@@ -110,6 +111,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
           cost-centre: '<cost-centre>'
+          vanity-name: '<project-name>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -54,7 +54,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
       **Cost Centre Name:** TPS Reports
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
-      **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
+      **Editors:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
       **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
@@ -79,7 +79,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
-          owners: [
+          editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -2,6 +2,7 @@ import { createMockDirectory } from '@backstage/backend-test-utils';
 import { fetchTemplateActionHandler } from '../__testUtils__/fetchTemplateActionHandler';
 import { getContextActionHandler } from '../__testUtils__/getContextActionHandler';
 import { projectParameters } from './project-create.test';
+import { createUser } from '../__testUtils__/createUser';
 import { skip } from '../__testUtils__/skip';
 
 jest.mock('ulidx', () => ({
@@ -25,14 +26,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
         ...projectParameters,
         machineSize: 'Medium',
       },
-      user: {
-        entity: {
-          apiVersion: 'backstage.io/v1alpha1',
-          kind: 'User',
-          metadata: { name: '' },
-          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
-        },
-      },
+      user: createUser({ email: 'jane.doe@gcp.hc-sc.gc.ca' }),
       mockDir,
     });
 

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -55,7 +55,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
       **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
-      **Editors:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
+      **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
 
@@ -83,7 +83,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],
-          editors: [
+          viewers: [
             { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -69,30 +69,32 @@ describe('rad-lab-data-science-create: fetch:template', () => {
     `);
   });
 
-  skip('win32')('The fetch:template action should render the expected changes for the Pull Request', async () => {
-    await fetchTemplateActionHandler({
-      template: { name: 'rad-lab-data-science-create' },
-      values: {
-        requestId: '<uuid>',
-        rootFolderId: '<root-folder-id>',
-        projectName: '<project-name>',
-        projectId: '<project-id>',
-        owners: [
-          { email: 'jane.doe@gcp.hc-sc.gc.ca' },
-          { email: 'john.doe@gcp.hc-sc.gc.ca' },
-        ],
-        editors: [
-          { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-          { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-          { email: 'john.campbell@gcp.hc-sc.gc.ca' },
-        ],
-        costCentre: 'ABC123456789',
-        catalogEntityOwner: 'user:default/jane.doe'
-      },
-      mockDir,
-    });
+  skip('win32')(
+    'The fetch:template action should render the expected changes for the Pull Request',
+    async () => {
+      await fetchTemplateActionHandler({
+        template: { name: 'rad-lab-data-science-create' },
+        values: {
+          requestId: '<uuid>',
+          rootFolderId: '<root-folder-id>',
+          projectName: '<project-name>',
+          projectId: '<project-id>',
+          owners: [
+            { email: 'jane.doe@gcp.hc-sc.gc.ca' },
+            { email: 'john.doe@gcp.hc-sc.gc.ca' },
+          ],
+          editors: [
+            { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+            { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+            { email: 'john.campbell@gcp.hc-sc.gc.ca' },
+          ],
+          costCentre: 'ABC123456789',
+          catalogEntityOwner: 'user:default/jane.doe',
+        },
+        mockDir,
+      });
 
-    expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
+      expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
       {
         "claim.yaml": "---
       apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
@@ -115,5 +117,6 @@ describe('rad-lab-data-science-create: fetch:template', () => {
       ",
       }
     `);
-  });
+    },
+  );
 });

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -75,6 +75,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           projectId: '<project-id>',
           projectLabels: {
             'cost-centre': '<cost-centre>',
+            'vanity-name': '<project-name>',
           },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
@@ -110,6 +111,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
           cost-centre: '<cost-centre>'
+          vanity-name: '<project-name>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -55,7 +55,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
       **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
-      **Editors:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
+      **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
 
@@ -83,7 +83,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],
-          editors: [
+          viewers: [
             { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -2,6 +2,7 @@ import { createMockDirectory } from '@backstage/backend-test-utils';
 import { fetchTemplateActionHandler } from '../__testUtils__/fetchTemplateActionHandler';
 import { getContextActionHandler } from '../__testUtils__/getContextActionHandler';
 import { projectParameters } from './project-create.test';
+import { createUser } from '../__testUtils__/createUser';
 import { skip } from '../__testUtils__/skip';
 
 jest.mock('ulidx', () => ({
@@ -25,14 +26,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
         ...projectParameters,
         machineSize: 'Medium',
       },
-      user: {
-        entity: {
-          apiVersion: 'backstage.io/v1alpha1',
-          kind: 'User',
-          metadata: { name: '' },
-          spec: { profile: { email: 'jane.doe@gcp.hc-sc.gc.ca' } },
-        },
-      },
+      user: createUser({ email: 'jane.doe@gcp.hc-sc.gc.ca' }),
       mockDir,
     });
 

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -69,30 +69,32 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
     `);
   });
 
-  skip('win32')('The fetch:template action should render the expected changes for the Pull Request', async () => {
-    await fetchTemplateActionHandler({
-      template: { name: 'rad-lab-gen-ai-create' },
-      values: {
-        requestId: '<uuid>',
-        rootFolderId: '<root-folder-id>',
-        projectName: '<project-name>',
-        projectId: '<project-id>',
-        owners: [
-          { email: 'jane.doe@gcp.hc-sc.gc.ca' },
-          { email: 'john.doe@gcp.hc-sc.gc.ca' },
-        ],
-        editors: [
-          { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-          { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-          { email: 'john.campbell@gcp.hc-sc.gc.ca' },
-        ],
-        costCentre: 'ABC123456789',
-        catalogEntityOwner: 'user:default/jane.doe'
-      },
-      mockDir,
-    });
+  skip('win32')(
+    'The fetch:template action should render the expected changes for the Pull Request',
+    async () => {
+      await fetchTemplateActionHandler({
+        template: { name: 'rad-lab-gen-ai-create' },
+        values: {
+          requestId: '<uuid>',
+          rootFolderId: '<root-folder-id>',
+          projectName: '<project-name>',
+          projectId: '<project-id>',
+          owners: [
+            { email: 'jane.doe@gcp.hc-sc.gc.ca' },
+            { email: 'john.doe@gcp.hc-sc.gc.ca' },
+          ],
+          editors: [
+            { email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+            { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+            { email: 'john.campbell@gcp.hc-sc.gc.ca' },
+          ],
+          costCentre: 'ABC123456789',
+          catalogEntityOwner: 'user:default/jane.doe',
+        },
+        mockDir,
+      });
 
-    expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
+      expect(mockDir.content({ path: 'workspace' })).toMatchInlineSnapshot(`
       {
         "claim.yaml": "---
       apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
@@ -115,5 +117,6 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
       ",
       }
     `);
-  });
+    },
+  );
 });

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -73,6 +73,9 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
+          projectLabels: {
+            'cost-centre': '<cost-centre>',
+          },
           editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
@@ -82,7 +85,6 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
             { email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
             { email: 'john.campbell@gcp.hc-sc.gc.ca' },
           ],
-          costCentre: 'ABC123456789',
           catalogEntityOwner: 'user:default/jane.doe',
         },
         mockDir,
@@ -107,7 +109,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           - user:alex.mcdonald@gcp.hc-sc.gc.ca
           - user:john.campbell@gcp.hc-sc.gc.ca
         labels:
-          cost-centre: abc123456789
+          cost-centre: '<cost-centre>'
       ",
       }
     `);

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -54,7 +54,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
       **Cost Centre Name:** TPS Reports
       **Justification:** This project will be used for testing our custom action.
       **Section 32 Manager Email:** alice.grady@gcp.hc-sc.gc.ca
-      **Owners:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
+      **Editors:** jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca
       **Viewers:** samantha.jones@gcp.hc-sc.gc.ca, alex.mcdonald@gcp.hc-sc.gc.ca, john.campbell@gcp.hc-sc.gc.ca
 
       ### Budget
@@ -79,7 +79,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           rootFolderId: '<root-folder-id>',
           projectName: '<project-name>',
           projectId: '<project-id>',
-          owners: [
+          editors: [
             { email: 'jane.doe@gcp.hc-sc.gc.ca' },
             { email: 'john.doe@gcp.hc-sc.gc.ca' },
           ],

--- a/backstage/templates/add-user/template.yaml
+++ b/backstage/templates/add-user/template.yaml
@@ -34,6 +34,9 @@ spec:
             catalogFilter:
               kind: Group
     - title: Pull Request
+      backstage:permissions:
+        tags:
+          - template-developer
       backstage:featureFlag: template-developer
       properties:
         pullRequestAction:
@@ -66,6 +69,9 @@ spec:
     - id: debug-pull-request
       name: Debug Pull Request
       action: debug:workspace
+      backstage:permissions:
+        tags:
+          - template-developer
       if: ${{ parameters.pullRequestAction == 'Diff Only' }}
       backstage:featureFlag: template-developer
       input:

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ${{values.projectId}}
   title: ${{values.projectName}}
   annotations:
-    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/${{values.pr_targetPath}}/
+    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/${{values.sourceLocation}}
     backstage.io/source-template: template:default/project-create
     cloud.google.com/project: ${{values.projectId}}
 spec:

--- a/backstage/templates/project-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml
@@ -8,8 +8,8 @@ spec:
   projectName: ${{values.projectName}}
   projectId: ${{values.projectId}}
   projectEditors:
-  {%- for owner in values.owners %}
-    - user:${{owner.email}}
+  {%- for editor in values.editors %}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}

--- a/backstage/templates/project-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml
@@ -16,4 +16,6 @@ spec:
     - user:${{viewer.email}}
   {%- endfor %}
   labels:
-    cost-centre: ${{values.costCentre | lower}}
+  {%- for key, value in values.projectLabels %}
+    ${{ key }}: '${{ value }}'
+  {%- endfor %}

--- a/backstage/templates/project-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml
@@ -12,8 +12,8 @@ spec:
     - user:${{owner.email}}
   {%- endfor %}
   projectViewers:
-  {%- for editor in values.editors %}
-    - user:${{editor.email}}
+  {%- for viewer in values.viewers %}
+    - user:${{viewer.email}}
   {%- endfor %}
   labels:
     cost-centre: ${{values.costCentre | lower}}

--- a/backstage/templates/project-create/pull-request-description.njk
+++ b/backstage/templates/project-create/pull-request-description.njk
@@ -16,7 +16,7 @@ This PR was created using Backstage.
 **Justification:** {{justification}}
 **Section 32 Manager Email:** {{section32ManagerEmail}}
 **Owners:** {{owners | map('email') | join(', ')}}
-**Editors:** {{editors | map('email') | join(', ')}}
+**Viewers:** {{viewers | map('email') | join(', ')}}
 
 ### Budget
 

--- a/backstage/templates/project-create/pull-request-description.njk
+++ b/backstage/templates/project-create/pull-request-description.njk
@@ -15,7 +15,7 @@ This PR was created using Backstage.
 **Cost Centre Name:** {{costCentreName}}
 **Justification:** {{justification}}
 **Section 32 Manager Email:** {{section32ManagerEmail}}
-**Owners:** {{owners | map('email') | join(', ')}}
+**Editors:** {{editors | map('email') | join(', ')}}
 **Viewers:** {{viewers | map('email') | join(', ')}}
 
 ### Budget

--- a/backstage/templates/project-create/template.yaml
+++ b/backstage/templates/project-create/template.yaml
@@ -68,15 +68,15 @@ spec:
             rows: 2
         owners:
           title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by comma.
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:
             rows: 2
           ui:placeholder: jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca, steve.smith@gcp.hc-sc.gc.ca
-        editors:
-          title: Editors
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by comma.
+        viewers:
+          title: Viewers
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to view this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/templates/project-create/template.yaml
+++ b/backstage/templates/project-create/template.yaml
@@ -66,9 +66,9 @@ spec:
           ui:widget: textarea
           ui:options:
             rows: 2
-        owners:
-          title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
+        editors:
+          title: Editors
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/templates/project-create/template.yaml
+++ b/backstage/templates/project-create/template.yaml
@@ -99,6 +99,9 @@ spec:
             rows: 2
           ui:placeholder: jane.doe@phac-aspc.gc.ca, john.doe@phac-aspc.gc.ca, steve.smith@phac-aspc.gc.ca
     - title: Pull Request
+      backstage:permissions:
+        tags:
+          - template-developer
       backstage:featureFlag: template-developer
       properties:
         pullRequestAction:
@@ -128,6 +131,9 @@ spec:
     - id: debug-pull-request
       name: Debug Pull Request
       action: debug:workspace
+      backstage:permissions:
+        tags:
+          - template-developer
       if: ${{ parameters.pullRequestAction == 'Diff Only' }}
       backstage:featureFlag: template-developer
       input:

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
@@ -8,8 +8,8 @@ spec:
   projectName: ${{values.projectName}}
   projectId: ${{values.projectId}}
   projectEditors:
-  {%- for owner in values.owners %}
-    - user:${{owner.email}}
+  {%- for editor in values.editors %}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
@@ -16,4 +16,6 @@ spec:
     - user:${{viewer.email}}
   {%- endfor %}
   labels:
-    cost-centre: ${{values.costCentre | lower}}
+  {%- for key, value in values.projectLabels %}
+    ${{ key }}: '${{ value }}'
+  {%- endfor %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml
@@ -12,8 +12,8 @@ spec:
     - user:${{owner.email}}
   {%- endfor %}
   projectViewers:
-  {%- for editor in values.editors %}
-    - user:${{editor.email}}
+  {%- for viewer in values.viewers %}
+    - user:${{viewer.email}}
   {%- endfor %}
   labels:
     cost-centre: ${{values.costCentre | lower}}

--- a/backstage/templates/rad-lab-data-science-create/template.yaml
+++ b/backstage/templates/rad-lab-data-science-create/template.yaml
@@ -71,15 +71,15 @@ spec:
             rows: 2
         owners:
           title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by comma.
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:
             rows: 2
           ui:placeholder: jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca, steve.smith@gcp.hc-sc.gc.ca
-        editors:
-          title: Editors
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by comma.
+        viewers:
+          title: Viewers
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to view this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/templates/rad-lab-data-science-create/template.yaml
+++ b/backstage/templates/rad-lab-data-science-create/template.yaml
@@ -122,6 +122,9 @@ spec:
             - Large
 
     - title: Pull Request
+      backstage:permissions:
+        tags:
+          - template-developer
       backstage:featureFlag: template-developer
       properties:
         pullRequestAction:
@@ -151,6 +154,9 @@ spec:
     - id: debug-pull-request
       name: Debug Pull Request
       action: debug:workspace
+      backstage:permissions:
+        tags:
+          - template-developer
       if: ${{ parameters.pullRequestAction == 'Diff Only' }}
       backstage:featureFlag: template-developer
       input:

--- a/backstage/templates/rad-lab-data-science-create/template.yaml
+++ b/backstage/templates/rad-lab-data-science-create/template.yaml
@@ -69,9 +69,9 @@ spec:
           ui:widget: textarea
           ui:options:
             rows: 2
-        owners:
-          title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
+        editors:
+          title: Editors
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
@@ -8,8 +8,8 @@ spec:
   projectName: ${{values.projectName}}
   projectId: ${{values.projectId}}
   projectEditors:
-  {%- for owner in values.owners %}
-    - user:${{owner.email}}
+  {%- for editor in values.editors %}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
@@ -16,4 +16,6 @@ spec:
     - user:${{viewer.email}}
   {%- endfor %}
   labels:
-    cost-centre: ${{values.costCentre | lower}}
+  {%- for key, value in values.projectLabels %}
+    ${{ key }}: '${{ value }}'
+  {%- endfor %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml
@@ -12,8 +12,8 @@ spec:
     - user:${{owner.email}}
   {%- endfor %}
   projectViewers:
-  {%- for editor in values.editors %}
-    - user:${{editor.email}}
+  {%- for viewer in values.viewers %}
+    - user:${{viewer.email}}
   {%- endfor %}
   labels:
     cost-centre: ${{values.costCentre | lower}}

--- a/backstage/templates/rad-lab-gen-ai-create/template.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/template.yaml
@@ -71,15 +71,15 @@ spec:
             rows: 2
         owners:
           title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by comma.
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:
             rows: 2
           ui:placeholder: jane.doe@gcp.hc-sc.gc.ca, john.doe@gcp.hc-sc.gc.ca, steve.smith@gcp.hc-sc.gc.ca
-        editors:
-          title: Editors
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by comma.
+        viewers:
+          title: Viewers
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to view this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/templates/rad-lab-gen-ai-create/template.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/template.yaml
@@ -122,6 +122,9 @@ spec:
             - Large
 
     - title: Pull Request
+      backstage:permissions:
+        tags:
+          - template-developer
       backstage:featureFlag: template-developer
       properties:
         pullRequestAction:
@@ -151,6 +154,9 @@ spec:
     - id: debug-pull-request
       name: Debug Pull Request
       action: debug:workspace
+      backstage:permissions:
+        tags:
+          - template-developer
       if: ${{ parameters.pullRequestAction == 'Diff Only' }}
       backstage:featureFlag: template-developer
       input:

--- a/backstage/templates/rad-lab-gen-ai-create/template.yaml
+++ b/backstage/templates/rad-lab-gen-ai-create/template.yaml
@@ -69,9 +69,9 @@ spec:
           ui:widget: textarea
           ui:options:
             rows: 2
-        owners:
-          title: Owners
-          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should own this service, separated by a comma.
+        editors:
+          title: Editors
+          ui:description: The `@gcp.hc-sc.gc.ca` email addresses of users who should be able to edit this service, separated by a comma.
           type: string
           ui:widget: textarea
           ui:options:

--- a/backstage/yarn.lock
+++ b/backstage/yarn.lock
@@ -9371,7 +9371,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -9402,12 +9402,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
   version "18.3.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.13.1 || ^17.0.0":
+  version "17.0.80"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
+  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/request@^2.47.1", "@types/request@^2.48.8":
@@ -9441,6 +9450,11 @@
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.7.tgz#dab4d16ba7568e9846c454a8764f33c5d98e5524"
   integrity sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==
+
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"

--- a/root-sync/base/crossplane/project/xrd-project.yaml
+++ b/root-sync/base/crossplane/project/xrd-project.yaml
@@ -44,9 +44,12 @@ spec:
                   properties:
                     cost-centre:
                       type: string
+                    vanity-name:
+                      type: string
                     # Additional user-defined labels are allowed. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#controlling-pruning.
                   required:
                     - cost-centre
+                    - vanity-name
               required:
                 - rootFolderId
                 - projectName

--- a/root-sync/base/crossplane/rad-lab/data-science/composition-data-science.yaml
+++ b/root-sync/base/crossplane/rad-lab/data-science/composition-data-science.yaml
@@ -20,7 +20,8 @@ spec:
           projectId: "TO BE PATCHED"
           projectEditors: ["TO BE PATCHED"]
           projectViewers: ["TO BE PATCHED"]
-    
+          labels: "TO BE PATCHED"
+
       patches:
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.projectName"
@@ -32,6 +33,8 @@ spec:
           toFieldPath: "spec.projectEditors"
         - fromFieldPath: "spec.projectViewers"
           toFieldPath: "spec.projectViewers"
+        - fromFieldPath: "spec.labels"
+          toFieldPath: "spec.labels"
 
     - name: TERRAFORM-CONFIG
       base:
@@ -109,7 +112,7 @@ spec:
                   forProvider:
                     module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/data-science?ref=main
                     source: Remote
-                    vars: 
+                    vars:
                       ##
                       # Project
                       ##
@@ -138,7 +141,7 @@ spec:
                         value: "false"
                       - key: set_external_ip_policy
                         value: "false"
-                      
+
                       ##
                       # (Option) Deep Learning VM Image
                       #

--- a/root-sync/base/crossplane/rad-lab/data-science/xrd-data-science.yaml
+++ b/root-sync/base/crossplane/rad-lab/data-science/xrd-data-science.yaml
@@ -39,6 +39,18 @@ spec:
                   type: array
                   items:
                     type: string
+                labels:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                  properties:
+                    cost-centre:
+                      type: string
+                    vanity-name:
+                      type: string
+                    # Additional user-defined labels are allowed. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#controlling-pruning.
+                  required:
+                    - cost-centre
+                    - vanity-name
               required:
                 # Base Properties
                 - rootFolderId
@@ -46,3 +58,4 @@ spec:
                 - projectId
                 - projectEditors
                 - projectViewers
+                - labels

--- a/root-sync/base/crossplane/rad-lab/gen-ai/composition-gen-ai.yaml
+++ b/root-sync/base/crossplane/rad-lab/gen-ai/composition-gen-ai.yaml
@@ -170,7 +170,7 @@ spec:
                       - key: create_usermanaged_notebook
                         value: "false"
           references:
-            - dependsOn: # GenAi requires a base project with budget.
+            - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
                 name: "TO BE PATCHED"

--- a/root-sync/base/crossplane/rad-lab/gen-ai/xrd-gen-ai.yaml
+++ b/root-sync/base/crossplane/rad-lab/gen-ai/xrd-gen-ai.yaml
@@ -45,9 +45,12 @@ spec:
                   properties:
                     cost-centre:
                       type: string
+                    vanity-name:
+                      type: string
                     # Additional user-defined labels are allowed. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#controlling-pruning.
                   required:
                     - cost-centre
+                    - vanity-name
               required:
                 # Base Properties
                 - rootFolderId

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -63,9 +63,11 @@ spec:
                   - user:sean.poulter@gcp.hc-sc.gc.ca
                 labels:
                   cost-centre: 'abc123456789'
+                  vanity-name: '($projectName)'
 
         - description: Assert the ProjectClaim has been created
           assert:
+            timeout: 5m
             resource:
               apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
               kind: ProjectClaim
@@ -90,7 +92,8 @@ spec:
                 annotations:
                   cnrm.cloud.google.com/auto-create-network: "false"
                 labels:
-                  cost-centre: abc123456789
+                  cost-centre: 'abc123456789'
+                  vanity-name: '($projectName)'
               spec:
                 name: ($projectName)
                 resourceID: ($projectId)

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -62,7 +62,7 @@ spec:
                   - user:sean.poulter@focisolutions.com
                   - user:sean.poulter@gcp.hc-sc.gc.ca
                 labels:
-                  cost-centre: abc123456789
+                  cost-centre: 'abc123456789'
 
         - description: Assert the ProjectClaim has been created
           assert:


### PR DESCRIPTION
> [!NOTE]
> This PR depends on #334. Let's get that PR in first.

--

This PR closes #264.

### Proposed Changes

- Enable permissions
- Add a custom permissions policy
- Restrict access to the template input parameters and actions tagged `template-developer`

### Screenshots / Demo

This video starts with the permissions restricted to members of an arbitrary group. They don't see the **Pull Request** section, and the template creates a PR.

Then we enable the permission to members of the `platform-team` group and we can debug templates without opening PRs as expected. 🎉 

https://github.com/PHACDataHub/sci-portal/assets/98067886/612c2f7a-1d61-4771-8c11-178b1e9adef3

