### PR TITLE
Delete orphaned Catalog entities

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -39,6 +39,7 @@ backend:
 
 catalog:
   readonly: true
+  orphanStrategy: delete
   rules:
     - allow: [Component, System, API, Resource, Location, User, Group]
   locations:

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -77,6 +77,7 @@ enableExperimentalRedirectFlow: true
 
 catalog:
   readonly: true
+  orphanStrategy: delete
   rules:
     - allow: [Component, System, API, Resource, Location, User, Group]
   locations:


### PR DESCRIPTION
This PR closes #355.

### Proposed Changes

- Backstage will prune Catalog entities that no longer exist in the external source of truth (GitHub).
