### PR TITLE
Remove unused GCP provider

### DIFF
--- a/bootstrap/crossplane/templates/gcp/controller-config.yaml
+++ b/bootstrap/crossplane/templates/gcp/controller-config.yaml
@@ -1,8 +1,0 @@
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
-metadata:
-  name: gcp-controller-config
-  annotations:    
-    iam.gke.io/gcp-service-account: ${KCC_SERVICEACCOUNT_EMAIL}
-spec:
-  serviceAccountName: ${KCC_SERVICEACCOUNT}

--- a/bootstrap/crossplane/templates/gcp/provider-config.yaml
+++ b/bootstrap/crossplane/templates/gcp/provider-config.yaml
@@ -1,8 +1,0 @@
-apiVersion: gcp.upbound.io/v1beta1
-kind: ProviderConfig
-metadata:
-  name: workload-id-provider-config
-spec:
-  credentials:
-    source: InjectedIdentity
-  projectID: ${GCP_PROJECT_ID}

--- a/bootstrap/crossplane/templates/gcp/provider.yaml
+++ b/bootstrap/crossplane/templates/gcp/provider.yaml
@@ -1,8 +1,0 @@
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-gcp-storage
-spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0
-  controllerConfigRef:
-    name: gcp-controller-config

--- a/bootstrap/crossplane_install.sh
+++ b/bootstrap/crossplane_install.sh
@@ -8,11 +8,6 @@ for var in GCP_PROJECT_ID GCP_REGION KCC_SERVICEACCOUNT KCC_SERVICEACCOUNT_EMAIL
     fi
 done
 
-# Create manifests for the GCP provider from templates
-envsubst < ./crossplane/templates/gcp/controller-config.yaml > ./crossplane/providers/gcp/controller-config.yaml
-envsubst < ./crossplane/templates/gcp/provider.yaml > ./crossplane/providers/gcp/provider.yaml
-envsubst < ./crossplane/templates/gcp/provider-config.yaml > ./crossplane/providers/gcp/config/provider-config.yaml
-
 # Create manifests for the Terraform provider from templates
 envsubst < ./crossplane/templates/terrafrom/deployment-runtime-config.yaml > ./crossplane/providers/terraform/deployment-runtime-config.yaml
 envsubst < ./crossplane/templates/terrafrom/provider.yaml > ./crossplane/providers/terraform/provider.yaml
@@ -37,7 +32,6 @@ kubectl apply -f crossplane/providers/terraform
 
 # Wait for the Providers to be ready
 kubectl wait --for=condition=ready pod -l pkg.crossplane.io/provider=provider-terraform -n crossplane-system --timeout=300s
-kubectl wait --for=condition=ready pod -l pkg.crossplane.io/provider=provider-gcp-storage -n crossplane-system --timeout=300s
 
 # Configure Crossplane providers
 # Note: Providres CRDS are required to successfully apply the configurations


### PR DESCRIPTION
This PR closes #385.

### Proposed Changes

- Remove the unused Terraform provider

### Notes

> [!NOTE]  
> We can remove the `ControllerConfig`, `ProviderConfig`, and `Provider` from the cluster.

* I'm not sure if `upbound-provider-family-gcp` was installed with this, or if we should take additional steps to tidy up.
