### PR TITLE
feat: add annotation and label for k8s plugin

### DIFF
--- a/DMIA-PHAC/SciencePlatform/phx-01hzjep5af6/catalog-info.yaml
+++ b/DMIA-PHAC/SciencePlatform/phx-01hzjep5af6/catalog-info.yaml
@@ -9,6 +9,7 @@ metadata:
     backstage.io/source-template: template:default/project-create
     cloud.google.com/project: phx-01hzjep5af6
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: vedant.thapa@phac-aspc.gc.ca
+    backstage.io/kubernetes-id: phx-01hzjep5af6
 spec:
   type: project
   owner: user:default/vedant.thapa

--- a/DMIA-PHAC/SciencePlatform/phx-01hzjep5af6/claim.yaml
+++ b/DMIA-PHAC/SciencePlatform/phx-01hzjep5af6/claim.yaml
@@ -3,6 +3,8 @@ apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
 kind: ProjectClaim
 metadata:
   name: phx-vedantthapa-1e5a67ec-7012-46cf-8a30-ef198c71ad88
+  labels:
+    backstage.io/kubernetes-id: phx-01hzjep5af6
 spec:
   rootFolderId: '108494461414'
   projectName: phx-vedantthapa


### PR DESCRIPTION
- Add annotation for backstage entity
- Add label to k8s claim

Apparently backstage requires to add a label instead of an annotation on a kubernetes resources to surface it on the catalog. See [this](https://backstage.io/docs/features/kubernetes/configuration/#surfacing-your-kubernetes-components-as-part-of-an-entity).

Relates to #399, #393.