### PR TITLE
Create PRs in the sci-portal-users repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ AUTH_GOOGLE_ALLOWED_DOMAINS=gcp.hc-sc.gc.ca,focisolutions.com
 
 # Backstage Templates
 GITOPS_REPO_OWNER=PHACDataHub
-GITOPS_REPO_NAME=sci-portal
+GITOPS_REPO_NAME=sci-portal-users
 GCP_BILLING_ACCOUNT_ID=
 
 # Backstage Static tokens

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -47,35 +47,30 @@ catalog:
     - allow: [Component, System, API, Resource, Location, User, Group, Template]
   providers:
     github:
-      # Load entities sci-portal-users repo.
+
+      # Include the following directories from PHACDataHub/sci-portal-users:
+      #   ├── DMIA-PHAC/**/catalog-info.yaml
+      #   ├── groups/**/*.yaml
+      #   └── users/**/*.yaml
       sci-portal-users:
         organization: 'PHACDataHub'
         filters:
           repository: '^sci-portal-users$'
           branch: 'main'
-        catalogPath: '/**/*.yaml'
+        catalogPath: '{DMIA-PHAC/**/catalog-info.yaml,groups/**/*.yaml,users/**/*.yaml}'
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }
 
-      # Load entities from the sci-portal repo.
+      # Include the following directories from PHACDataHub/sci-portal:
+      #   ├── backstage/catalog-info.yaml
+      #   └── backstage/templates/*/template.yaml
       sci-portal:
         organization: 'PHACDataHub'
         filters:
           repository: '^sci-portal$'
           branch: 'main'
-        catalogPath: '/**/catalog-info.yaml'
-        schedule:
-          frequency: { minutes: 30 }
-          timeout: { minutes: 3 }
-
-      # Load entities from the sci-portal repo.
-      sci-portal-templates:
-        organization: 'PHACDataHub'
-        filters:
-          repository: '^sci-portal$'
-          branch: 'main'
-        catalogPath: '/backstage/templates/*/template.yaml'
+        catalogPath: '{backstage/catalog-info.yaml,backstage/templates/*/template.yaml}'
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }

--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -89,35 +89,30 @@ catalog:
     - allow: [Component, System, API, Resource, Location, User, Group, Template]
   providers:
     github:
-      # Load entities sci-portal-users repo.
+
+      # Include the following directories from PHACDataHub/sci-portal-users:
+      #   ├── DMIA-PHAC/**/catalog-info.yaml
+      #   ├── groups/**/*.yaml
+      #   └── users/**/*.yaml
       sci-portal-users:
         organization: 'PHACDataHub'
         filters:
           repository: '^sci-portal-users$'
           branch: 'main'
-        catalogPath: '/**/*.yaml'
+        catalogPath: '{DMIA-PHAC/**/catalog-info.yaml,groups/**/*.yaml,users/**/*.yaml}'
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }
 
-      # Load entities from the sci-portal repo.
+      # Include the following directories from PHACDataHub/sci-portal:
+      #   ├── backstage/catalog-info.yaml
+      #   └── backstage/templates/*/template.yaml
       sci-portal:
         organization: 'PHACDataHub'
         filters:
           repository: '^sci-portal$'
           branch: 'main'
-        catalogPath: '/**/catalog-info.yaml'
-        schedule:
-          frequency: { minutes: 30 }
-          timeout: { minutes: 3 }
-
-      # Load entities from the sci-portal repo.
-      sci-portal-templates:
-        organization: 'PHACDataHub'
-        filters:
-          repository: '^sci-portal$'
-          branch: 'main'
-        catalogPath: '/backstage/templates/*/template.yaml'
+        catalogPath: '{backstage/catalog-info.yaml,backstage/templates/*/template.yaml}'
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -134,7 +134,7 @@ describe('project-create: fetch:template', () => {
           name: <project-id>
           title: <project-name>
           annotations:
-            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/DMIA-PHAC/SciencePlatform/<project-id>/
+            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/project-create
             cloud.google.com/project: <project-id>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -119,7 +119,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           name: <project-id>
           title: <project-name>
           annotations:
-            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/DMIA-PHAC/SciencePlatform/<project-id>/
+            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/rad-lab-data-science-create
             cloud.google.com/project: <project-id>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -119,7 +119,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           name: <project-id>
           title: <project-name>
           annotations:
-            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/DMIA-PHAC/SciencePlatform/<project-id>/
+            backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/rad-lab-gen-ai-create
             cloud.google.com/project: <project-id>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -5,7 +5,7 @@ metadata:
   name: ${{values.projectId}}
   title: ${{values.projectName}}
   annotations:
-    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/${{values.sourceLocation}}
+    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/project-create
     cloud.google.com/project: ${{values.projectId}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -5,7 +5,7 @@ metadata:
   name: ${{values.projectId}}
   title: ${{values.projectName}}
   annotations:
-    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/${{values.sourceLocation}}
+    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/rad-lab-data-science-create
     cloud.google.com/project: ${{values.projectId}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -5,7 +5,7 @@ metadata:
   name: ${{values.projectId}}
   title: ${{values.projectName}}
   annotations:
-    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal/${{values.sourceLocation}}
+    backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/rad-lab-gen-ai-create
     cloud.google.com/project: ${{values.projectId}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}


### PR DESCRIPTION
This PR is part of #320.

### Proposed Changes

- Create PRs in the **sci-portal-users** repo.
- Update the GitHub Discovery to find Catalog entities using `{}`s

### Notes

> [!NOTE]  
> Update the `GITOPS_REPO_NAME` environment variable in the cluster and restart the pod/deployment.

### Test Plan

It will create PRs in the right repo - https://github.com/PHACDataHub/sci-portal-users/pull/12.