### PR TITLE
Delete the test branch

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ startsWith( github.event.pull_request.title, '[Test] ') }}
     runs-on: ubuntu-latest
     steps:
+    steps:
+      - uses: actions/checkout@v4
       - name: Close PR
         run: gh pr close --delete-branch "$PR_URL"
         env:


### PR DESCRIPTION
### Problem

This GitHub Workflow does not remove test branches. The Workflow actually fails because there is no local branch to remove.

### Proposed Changes

- Checkout the repo so the `gh pr close` command _should_ succeed 🤞 
