### PR TITLE
Add links to Managed Notebooks on Google Cloud

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -123,6 +123,9 @@ describe('rad-lab-data-science-create: fetch:template', () => {
             backstage.io/source-template: template:default/rad-lab-data-science-create
             cloud.google.com/project: <project-id>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
+          links:
+            - title: View Managed Notebooks on Google Cloud
+              url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=<project-id>
         spec:
           type: rad-lab-module
           owner: user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -123,6 +123,9 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
             backstage.io/source-template: template:default/rad-lab-gen-ai-create
             cloud.google.com/project: <project-id>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
+          links:
+            - title: View Managed Notebooks on Google Cloud
+              url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=<project-id>
         spec:
           type: rad-lab-module
           owner: user:default/jane.doe

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -9,6 +9,9 @@ metadata:
     backstage.io/source-template: template:default/rad-lab-data-science-create
     cloud.google.com/project: ${{values.projectId}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}
+  links:
+    - title: View Managed Notebooks on Google Cloud
+      url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=${{values.projectId}}
 spec:
   type: rad-lab-module
   owner: ${{values.catalogEntityOwner}}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -9,6 +9,9 @@ metadata:
     backstage.io/source-template: template:default/rad-lab-gen-ai-create
     cloud.google.com/project: ${{values.projectId}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}
+  links:
+    - title: View Managed Notebooks on Google Cloud
+      url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=${{values.projectId}}
 spec:
   type: rad-lab-module
   owner: ${{values.catalogEntityOwner}}


### PR DESCRIPTION
This PR closes #418.

### Proposed Changes

- Add a link to the Managed Notebooks on the Entity

### Screenshot / Demo

<img width="2559" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/f008a2a7-c20c-4bb1-90a0-7ca85e836aa5">
