### PR TITLE
Add ownership Editors 

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/getContextActionHandler.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/__testUtils__/getContextActionHandler.ts
@@ -34,10 +34,12 @@ const getEntitiesByRefs = ({ entityRefs }: { entityRefs: string[] }) => {
     if (entityRef.startsWith('user:')) {
       const name = entityRef.replace(/^user:default[/]/, '');
       items.push({
+        metadata: {
+          name,
+        },
         spec: {
           profile: {
             email: `${name}@gcp.hc-sc.gc.ca`,
-            altEmail: `${name}@phac-aspc.gc.ca`,
           },
         },
       });

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -232,17 +232,17 @@ describe('provisioner', () => {
           'user:default/karen.schumacher',
         ],
         editors: [
-          'jane.doe@gcp.hc-sc.gc.ca',
-          'jeanne.smith@gcp.hc-sc.gc.ca',
-          'karen.schumacher@gcp.hc-sc.gc.ca',
+          { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
+          { ref: 'user:default/jeanne.smith', email: 'jeanne.smith@gcp.hc-sc.gc.ca' },
+          { ref: 'user:default/karen.schumacher', email: 'karen.schumacher@gcp.hc-sc.gc.ca' },
         ],
         viewerRefs: [
           'user:default/samantha.jones',
           'user:default/john.campbell',
         ],
         viewers: [
-          'samantha.jones@gcp.hc-sc.gc.ca',
-          'john.campbell@gcp.hc-sc.gc.ca',
+          { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+          { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
         ],
 
         // Backstage

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -233,16 +233,28 @@ describe('provisioner', () => {
         ],
         editors: [
           { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
-          { ref: 'user:default/jeanne.smith', email: 'jeanne.smith@gcp.hc-sc.gc.ca' },
-          { ref: 'user:default/karen.schumacher', email: 'karen.schumacher@gcp.hc-sc.gc.ca' },
+          {
+            ref: 'user:default/jeanne.smith',
+            email: 'jeanne.smith@gcp.hc-sc.gc.ca',
+          },
+          {
+            ref: 'user:default/karen.schumacher',
+            email: 'karen.schumacher@gcp.hc-sc.gc.ca',
+          },
         ],
         viewerRefs: [
           'user:default/samantha.jones',
           'user:default/john.campbell',
         ],
         viewers: [
-          { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-          { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
+          {
+            ref: 'user:default/samantha.jones',
+            email: 'samantha.jones@gcp.hc-sc.gc.ca',
+          },
+          {
+            ref: 'user:default/john.campbell',
+            email: 'john.campbell@gcp.hc-sc.gc.ca',
+          },
         ],
 
         // Backstage

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.test.ts
@@ -246,7 +246,7 @@ describe('provisioner', () => {
         ],
 
         // Backstage
-        catalogEntityOwner: 'user:default/jane.doe',
+        catalogEntityOwner: 'group:default/hcx-01an4z07by7-editors',
         sourceLocation: 'DMIA-PHAC/SciencePlatform/hcx-01an4z07by7/',
 
         // Additional properties that are not in the input schema are included in the output.

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -385,7 +385,7 @@ export const createProvisionTemplateAction = (options: {
         viewers,
 
         // Backstage
-        catalogEntityOwner: ctx.user.ref,
+        catalogEntityOwner: `group:default/${projectId}-editors`,
         sourceLocation,
       };
       ctx.output('template_values', templateValues);

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -84,7 +84,7 @@ const getGoogleCloudEmailsByRefs = async (
   token: string,
 ) => {
   const { items } = await catalogApi.getEntitiesByRefs(
-    { entityRefs, fields: ['spec.profile.email'] },
+    { entityRefs, fields: ['metadata.namespace', 'metadata.name', 'spec.profile.email'] },
     { token },
   );
 

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -94,7 +94,9 @@ const getGoogleCloudEmailsByRefs = async (
       continue;
     }
 
-    const ref = `user:${item.metadata.namespace ?? 'default'}/${item.metadata.name}`;
+    const ref = `user:${item.metadata.namespace ?? 'default'}/${
+      item.metadata.name
+    }`;
     const email = (item as CustomUserEntity).spec.profile.email;
 
     result.push({ ref, email });

--- a/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/actions/provisioner.ts
@@ -82,7 +82,7 @@ const getGoogleCloudEmailsByRefs = async (
   catalogApi: CatalogApi,
   entityRefs: string[],
   token: string,
-): Promise<string[]> => {
+) => {
   const { items } = await catalogApi.getEntitiesByRefs(
     { entityRefs, fields: ['spec.profile.email'] },
     { token },
@@ -94,10 +94,10 @@ const getGoogleCloudEmailsByRefs = async (
       continue;
     }
 
-    const email = (item as UserEntity).spec.profile?.email;
-    if (email) {
-      result.push(email);
-    }
+    const ref = `user:${item.metadata.namespace ?? 'default'}/${item.metadata.name}`;
+    const email = (item as CustomUserEntity).spec.profile.email;
+
+    result.push({ ref, email });
   }
   return result;
 };

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -176,6 +176,7 @@ describe('project-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          type: team
           children: []
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -158,6 +158,8 @@ describe('project-create: fetch:template', () => {
         metadata:
           name: <project-id>-editors
           title: <project-name> Editors
+          annotations:
+            cloud.google.com/project: <project-id>
         spec:
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -111,11 +111,14 @@ describe('project-create: fetch:template', () => {
               'team-name': '<team-name>',
               'vanity-name': '<project-name>',
             },
-            editors: ['jane.doe@gcp.hc-sc.gc.ca', 'john.doe@gcp.hc-sc.gc.ca'],
+            editors: [
+              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+            ],
             viewers: [
-              'samantha.jones@gcp.hc-sc.gc.ca',
-              'alex.mcdonald@gcp.hc-sc.gc.ca',
-              'john.campbell@gcp.hc-sc.gc.ca',
+              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
             catalogEntityOwner: 'user:default/jane.doe',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
@@ -148,6 +151,17 @@ describe('project-create: fetch:template', () => {
         spec:
           type: project
           owner: user:default/jane.doe
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-editors
+          title: <project-name> Editors
+        spec:
+          members:
+            - user:default/jane.doe
+            - user:default/john.doe
         ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -112,13 +112,28 @@ describe('project-create: fetch:template', () => {
               'vanity-name': '<project-name>',
             },
             editors: [
-              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/jane.doe',
+                email: 'jane.doe@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.doe',
+                email: 'john.doe@gcp.hc-sc.gc.ca',
+              },
             ],
             viewers: [
-              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/samantha.jones',
+                email: 'samantha.jones@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/alex.mcdonald',
+                email: 'alex.mcdonald@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.campbell',
+                email: 'john.campbell@gcp.hc-sc.gc.ca',
+              },
             ],
             catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -120,7 +120,7 @@ describe('project-create: fetch:template', () => {
               { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
               { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
-            catalogEntityOwner: 'user:default/jane.doe',
+            catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
             budgetAlertEmailRecipients: [
               'jane.doe@gcp.hc-sc.gc.ca',
@@ -150,7 +150,7 @@ describe('project-create: fetch:template', () => {
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
         spec:
           type: project
-          owner: user:default/jane.doe
+          owner: group:default/<project-id>-editors
 
         ---
         apiVersion: backstage.io/v1alpha1

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -176,6 +176,7 @@ describe('project-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          children: []
           members:
             - user:default/jane.doe
             - user:default/john.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -165,6 +165,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          children: []
           members:
             - user:default/jane.doe
             - user:default/john.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -96,11 +96,14 @@ describe('rad-lab-data-science-create: fetch:template', () => {
               'team-name': '<team-name>',
               'vanity-name': '<project-name>',
             },
-            editors: ['jane.doe@gcp.hc-sc.gc.ca', 'john.doe@gcp.hc-sc.gc.ca'],
+            editors: [
+              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+            ],
             viewers: [
-              'samantha.jones@gcp.hc-sc.gc.ca',
-              'alex.mcdonald@gcp.hc-sc.gc.ca',
-              'john.campbell@gcp.hc-sc.gc.ca',
+              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
             catalogEntityOwner: 'user:default/jane.doe',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
@@ -137,6 +140,17 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           type: rad-lab-module
           owner: user:default/jane.doe
           lifecycle: experimental
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-editors
+          title: <project-name> Editors
+        spec:
+          members:
+            - user:default/jane.doe
+            - user:default/john.doe
         ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -165,6 +165,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          type: team
           children: []
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -147,6 +147,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
         metadata:
           name: <project-id>-editors
           title: <project-name> Editors
+          annotations:
+            cloud.google.com/project: <project-id>
         spec:
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -97,13 +97,28 @@ describe('rad-lab-data-science-create: fetch:template', () => {
               'vanity-name': '<project-name>',
             },
             editors: [
-              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/jane.doe',
+                email: 'jane.doe@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.doe',
+                email: 'john.doe@gcp.hc-sc.gc.ca',
+              },
             ],
             viewers: [
-              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/samantha.jones',
+                email: 'samantha.jones@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/alex.mcdonald',
+                email: 'alex.mcdonald@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.campbell',
+                email: 'john.campbell@gcp.hc-sc.gc.ca',
+              },
             ],
             catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -105,7 +105,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
               { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
               { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
-            catalogEntityOwner: 'user:default/jane.doe',
+            catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
             budgetAlertEmailRecipients: [
               'jane.doe@gcp.hc-sc.gc.ca',
@@ -138,7 +138,7 @@ describe('rad-lab-data-science-create: fetch:template', () => {
               url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=<project-id>
         spec:
           type: rad-lab-module
-          owner: user:default/jane.doe
+          owner: group:default/<project-id>-editors
           lifecycle: experimental
 
         ---

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -165,6 +165,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          type: team
           children: []
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -147,6 +147,8 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
         metadata:
           name: <project-id>-editors
           title: <project-name> Editors
+          annotations:
+            cloud.google.com/project: <project-id>
         spec:
           members:
             - user:default/jane.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -96,11 +96,14 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
               'team-name': '<team-name>',
               'vanity-name': '<project-name>',
             },
-            editors: ['jane.doe@gcp.hc-sc.gc.ca', 'john.doe@gcp.hc-sc.gc.ca'],
+            editors: [
+              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+            ],
             viewers: [
-              'samantha.jones@gcp.hc-sc.gc.ca',
-              'alex.mcdonald@gcp.hc-sc.gc.ca',
-              'john.campbell@gcp.hc-sc.gc.ca',
+              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
+              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
             catalogEntityOwner: 'user:default/jane.doe',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
@@ -137,6 +140,17 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           type: rad-lab-module
           owner: user:default/jane.doe
           lifecycle: experimental
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-editors
+          title: <project-name> Editors
+        spec:
+          members:
+            - user:default/jane.doe
+            - user:default/john.doe
         ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -97,13 +97,28 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
               'vanity-name': '<project-name>',
             },
             editors: [
-              { ref: 'user:default/jane.doe', email: 'jane.doe@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.doe', email: 'john.doe@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/jane.doe',
+                email: 'jane.doe@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.doe',
+                email: 'john.doe@gcp.hc-sc.gc.ca',
+              },
             ],
             viewers: [
-              { ref: 'user:default/samantha.jones', email: 'samantha.jones@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
-              { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
+              {
+                ref: 'user:default/samantha.jones',
+                email: 'samantha.jones@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/alex.mcdonald',
+                email: 'alex.mcdonald@gcp.hc-sc.gc.ca',
+              },
+              {
+                ref: 'user:default/john.campbell',
+                email: 'john.campbell@gcp.hc-sc.gc.ca',
+              },
             ],
             catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -165,6 +165,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           annotations:
             cloud.google.com/project: <project-id>
         spec:
+          children: []
           members:
             - user:default/jane.doe
             - user:default/john.doe

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -105,7 +105,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
               { ref: 'user:default/alex.mcdonald', email: 'alex.mcdonald@gcp.hc-sc.gc.ca' },
               { ref: 'user:default/john.campbell', email: 'john.campbell@gcp.hc-sc.gc.ca' },
             ],
-            catalogEntityOwner: 'user:default/jane.doe',
+            catalogEntityOwner: 'group:default/<project-id>-editors',
             sourceLocation: 'DMIA-PHAC/SciencePlatform/<project-id>/',
             budgetAlertEmailRecipients: [
               'jane.doe@gcp.hc-sc.gc.ca',
@@ -138,7 +138,7 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
               url: https://console.cloud.google.com/vertex-ai/workbench/managed?project=<project-id>
         spec:
           type: rad-lab-module
-          owner: user:default/jane.doe
+          owner: group:default/<project-id>-editors
           lifecycle: experimental
 
         ---

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -12,3 +12,15 @@ metadata:
 spec:
   type: project
   owner: ${{values.catalogEntityOwner}}
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-editors
+  title: ${{values.projectName}} Editors
+spec:
+  members:
+    {%- for member in values.editors %}
+    - ${{member.ref}}
+    {%- endfor %}

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -22,6 +22,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  children: []
   members:
     {%- for member in values.editors %}
     - ${{member.ref}}

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -19,6 +19,8 @@ kind: Group
 metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
 spec:
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -22,6 +22,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  type: team
   children: []
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
@@ -14,9 +14,9 @@ spec:
   {%- endfor %}
   projectEditors:
   {%- for editor in values.editors %}
-    - user:${{editor}}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}
-    - user:${{viewer}}
+    - user:${{viewer.email}}
   {%- endfor %}

--- a/backstage/templates/project-create/pull-request-description.njk
+++ b/backstage/templates/project-create/pull-request-description.njk
@@ -11,8 +11,8 @@ This PR was created using Backstage.
 
 ### Team
 
-**Editors:** {{editors | join(', ')}}
-**Viewers:** {{viewers | join(', ')}}
+**Editors:** {{editors | map('email') | join(', ')}}
+**Viewers:** {{viewers | map('email') | join(', ')}}
 
 ### Administrative Details
 

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -26,6 +26,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  children: []
   members:
     {%- for member in values.editors %}
     - ${{member.ref}}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -23,6 +23,8 @@ kind: Group
 metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
 spec:
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -16,3 +16,15 @@ spec:
   type: rad-lab-module
   owner: ${{values.catalogEntityOwner}}
   lifecycle: experimental
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-editors
+  title: ${{values.projectName}} Editors
+spec:
+  members:
+    {%- for member in values.editors %}
+    - ${{member.ref}}
+    {%- endfor %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -26,6 +26,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  type: team
   children: []
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
@@ -14,9 +14,9 @@ spec:
   {%- endfor %}
   projectEditors:
   {%- for editor in values.editors %}
-    - user:${{editor}}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}
-    - user:${{viewer}}
+    - user:${{viewer.email}}
   {%- endfor %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -26,6 +26,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  children: []
   members:
     {%- for member in values.editors %}
     - ${{member.ref}}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -23,6 +23,8 @@ kind: Group
 metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
 spec:
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -16,3 +16,15 @@ spec:
   type: rad-lab-module
   owner: ${{values.catalogEntityOwner}}
   lifecycle: experimental
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-editors
+  title: ${{values.projectName}} Editors
+spec:
+  members:
+    {%- for member in values.editors %}
+    - ${{member.ref}}
+    {%- endfor %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -26,6 +26,7 @@ metadata:
   annotations:
     cloud.google.com/project: ${{values.projectId}}
 spec:
+  type: team
   children: []
   members:
     {%- for member in values.editors %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
@@ -14,9 +14,9 @@ spec:
   {%- endfor %}
   projectEditors:
   {%- for editor in values.editors %}
-    - user:${{editor}}
+    - user:${{editor.email}}
   {%- endfor %}
   projectViewers:
   {%- for viewer in values.viewers %}
-    - user:${{viewer}}
+    - user:${{viewer.email}}
   {%- endfor %}


### PR DESCRIPTION
Now that we've configured Config Sync to ignore Backstage manifest with Kustomize we can add the changes from #179 back in.

This PR closes #425.

### Proposed Changes

- Add a new `Group` for the Editors.
- Set the ownership to the `Group`
- Add the project ID as an annotation to the `Group`

### Test Plan

I've created https://github.com/PHACDataHub/sci-portal-users/pull/20/files#diff-cbe587c7c4e72abdfc21f9a7af5686ccfbbca289df88632d964bdf32ad6a8b55R20-R32 from this branch. It was missing the `type: team` and `children: []`.

### Screenshots / Demo

If we're not a member of the Platform Team:

<img width="1282" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/c58a4f00-c78f-4a78-9dcc-d7cc9674bfe4">

We can see the `Component` and `Resource` entities that we own:

<img width="1281" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/369ab8bb-25a0-4b4a-a96c-0b0cfd765c58">
