### PR TITLE
When there are no viewers the projectViewers should be an empty array

### DIFF
--- a/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
@@ -16,7 +16,11 @@ spec:
   {%- for editor in values.editors %}
     - user:${{editor.email}}
   {%- endfor %}
+  {%- if (values.viewers | length) == 0 %}
+  projectViewers: []
+  {%- else %}
   projectViewers:
   {%- for viewer in values.viewers %}
     - user:${{viewer.email}}
   {%- endfor %}
+  {%- endif %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
@@ -16,7 +16,11 @@ spec:
   {%- for editor in values.editors %}
     - user:${{editor.email}}
   {%- endfor %}
+  {%- if (values.viewers | length) == 0 %}
+  projectViewers: []
+  {%- else %}
   projectViewers:
   {%- for viewer in values.viewers %}
     - user:${{viewer.email}}
   {%- endfor %}
+  {%- endif %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
@@ -16,7 +16,11 @@ spec:
   {%- for editor in values.editors %}
     - user:${{editor.email}}
   {%- endfor %}
+  {%- if (values.viewers | length) == 0 %}
+  projectViewers: []
+  {%- else %}
   projectViewers:
   {%- for viewer in values.viewers %}
     - user:${{viewer.email}}
   {%- endfor %}
+  {%- endif %}


### PR DESCRIPTION
This PR closes #436.

### Problem

When there are no viewers, the output is invalid (undefined, not an array):

```yaml
  projectViewers:
```

### Proposed Changes

- Explicitly output an empty array

### Test Plan

<img width="2080" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/1289bee4-b95b-487a-b2ed-ec8fb298680c">
