### PR TITLE
Add group for viewers when templates submitted

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -196,7 +196,8 @@ describe('project-create: fetch:template', () => {
           members:
             - user:default/samantha.jones
             - user:default/alex.mcdonald
-            - user:default/john.campbell",
+            - user:default/john.campbell
+        ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: ProjectClaim

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -181,7 +181,22 @@ describe('project-create: fetch:template', () => {
           members:
             - user:default/jane.doe
             - user:default/john.doe
-        ",
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-viewers
+          title: <project-name> Viewers
+          annotations:
+            cloud.google.com/project: <project-id>
+        spec:
+          type: team
+          children: []
+          members:
+            - user:default/samantha.jones
+            - user:default/alex.mcdonald
+            - user:default/john.campbell",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: ProjectClaim

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -170,7 +170,22 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           members:
             - user:default/jane.doe
             - user:default/john.doe
-        ",
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-viewers
+          title: <project-name> Viewers
+          annotations:
+            cloud.google.com/project: <project-id>
+        spec:
+          type: team
+          children: []
+          members:
+            - user:default/samantha.jones
+            - user:default/alex.mcdonald
+            - user:default/john.campbell",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: RadLabDataScienceClaim

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -185,7 +185,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           members:
             - user:default/samantha.jones
             - user:default/alex.mcdonald
-            - user:default/john.campbell",
+            - user:default/john.campbell
+        ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: RadLabDataScienceClaim

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -170,6 +170,22 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           members:
             - user:default/jane.doe
             - user:default/john.doe
+
+        ---
+        apiVersion: backstage.io/v1alpha1
+        kind: Group
+        metadata:
+          name: <project-id>-viewers
+          title: <project-name> Viewers
+          annotations:
+            cloud.google.com/project: <project-id>
+        spec:
+          type: team
+          children: []
+          members:
+            - user:default/samantha.jones
+            - user:default/alex.mcdonald
+            - user:default/john.campbell
         ",
                 "claim.yaml": "---
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -40,7 +40,11 @@ metadata:
 spec:
   type: team
   children: []
+  {%- if (values.viewers | length) == 0 %}
+  members: []
+  {%- else %}
   members:
     {%- for member in values.viewers %}
     - ${{member.ref}}
     {%- endfor %}
+  {%- endif %}

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -28,3 +28,19 @@ spec:
     {%- for member in values.editors %}
     - ${{member.ref}}
     {%- endfor %}
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-viewers
+  title: ${{values.projectName}} Viewers
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
+spec:
+  type: team
+  children: []
+  members:
+    {%- for member in values.viewers %}
+    - ${{member.ref}}
+    {%- endfor %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -44,7 +44,11 @@ metadata:
 spec:
   type: team
   children: []
+  {%- if (values.viewers | length) == 0 %}
+  members: []
+  {%- else %}
   members:
     {%- for member in values.viewers %}
     - ${{member.ref}}
     {%- endfor %}
+  {%- endif %}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -32,3 +32,19 @@ spec:
     {%- for member in values.editors %}
     - ${{member.ref}}
     {%- endfor %}
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-viewers
+  title: ${{values.projectName}} Viewers
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
+spec:
+  type: team
+  children: []
+  members:
+    {%- for member in values.viewers %}
+    - ${{member.ref}}
+    {%- endfor %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -44,7 +44,11 @@ metadata:
 spec:
   type: team
   children: []
+  {%- if (values.viewers | length) == 0 %}
+  members: []
+  {%- else %}
   members:
     {%- for member in values.viewers %}
     - ${{member.ref}}
     {%- endfor %}
+  {%- endif %}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -32,3 +32,19 @@ spec:
     {%- for member in values.editors %}
     - ${{member.ref}}
     {%- endfor %}
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ${{values.projectId}}-viewers
+  title: ${{values.projectName}} Viewers
+  annotations:
+    cloud.google.com/project: ${{values.projectId}}
+spec:
+  type: team
+  children: []
+  members:
+    {%- for member in values.viewers %}
+    - ${{member.ref}}
+    {%- endfor %}


### PR DESCRIPTION
Closes #431 

Note: viewer group created but we don't currently  have any actions that should be locked down to specific groups so this group doesn't have any assigned permissions as of yet.