### PR TITLE
`metadata.name` length validated to not exceed 63 character limit

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -202,7 +202,9 @@ describe('project-create: fetch:template', () => {
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: ProjectClaim
         metadata:
-          name: <project-name>-<uuid>
+          name: <project-name>
+          annotations: 
+            requestId: <uuid>
         spec:
           rootFolderId: '<root-folder-id>'
           projectName: <project-name>

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -191,7 +191,9 @@ describe('rad-lab-data-science-create: fetch:template', () => {
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: RadLabDataScienceClaim
         metadata:
-          name: <project-name>-<uuid>
+          name: <project-name>
+          annotations: 
+            requestId: <uuid>
         spec:
           rootFolderId: '<root-folder-id>'
           projectName: <project-name>

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -191,7 +191,9 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
         apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
         kind: RadLabGenAIClaim
         metadata:
-          name: <project-name>-<uuid>
+          name: <project-name>
+          annotations: 
+            requestId: <uuid>
         spec:
           rootFolderId: '<root-folder-id>'
           projectName: <project-name>

--- a/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/claim.yaml.njk
@@ -2,7 +2,9 @@
 apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
 kind: ProjectClaim
 metadata:
-  name: ${{values.projectName}}-${{values.requestId}}
+  name: ${{values.projectName}}
+  annotations: 
+    requestId: ${{values.requestId}}
 spec:
   rootFolderId: '${{values.rootFolderId}}'
   projectName: ${{values.projectName}}

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
@@ -2,7 +2,9 @@
 apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
 kind: RadLabDataScienceClaim
 metadata:
-  name: ${{values.projectName}}-${{values.requestId}}
+  name: ${{values.projectName}}
+  annotations: 
+    requestId: ${{values.requestId}}
 spec:
   rootFolderId: '${{values.rootFolderId}}'
   projectName: ${{values.projectName}}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
@@ -2,7 +2,9 @@
 apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
 kind: RadLabGenAIClaim
 metadata:
-  name: ${{values.projectName}}-${{values.requestId}}
+  name: ${{values.projectName}}
+  annotations: 
+    requestId: ${{values.requestId}}
 spec:
   rootFolderId: '${{values.rootFolderId}}'
   projectName: ${{values.projectName}}


### PR DESCRIPTION
Closes #438 

Metadata Name should never be longer than 29 characters now. 
Moved request ID to annotations.

metadata name: 
`${ctx.input.parameters.department}${environment}-${ctx.input.parameters.vanityName}`

department = 2 char
environment = 1 char
vanityName = max 26 char
