### PR TITLE
Add validation for the label fields

### DIFF
--- a/backstage/templates/project-create/template.parameters.administration.yaml
+++ b/backstage/templates/project-create/template.parameters.administration.yaml
@@ -24,17 +24,25 @@ properties:
     title: Branch Acronym
     description: The branch within your department. The acronym must be lowercase with hyphens as separators.
     type: string
+    maxLength: 63
+    pattern: '([a-z0-9\-]+)'
   teamName:
     title: Team Name
     description: The team name associated with the project. The name must be lowercase with hyphens as separators.
     type: string
+    maxLength: 63
+    pattern: '([a-z0-9\-\_]+)'
   costCentre:
     title: Cost Centre
     type: string
+    maxLength: 63
+    pattern: '([a-z0-9\-\_]+)'
   costCentreName:
     title: Cost Centre Name
     description: The human-readable name for the Cost Centre.
     type: string
+    maxLength: 63
+    pattern: '([a-z0-9\-\_]+)'
   section32ManagerEmail:
     title: Section 32 Manager Email Address
     type: string

--- a/backstage/templates/project-create/template.parameters.administration.yaml
+++ b/backstage/templates/project-create/template.parameters.administration.yaml
@@ -22,27 +22,27 @@ properties:
       - Health Canada
   branch:
     title: Branch Acronym
-    description: The branch within your department. The acronym must be lowercase with hyphens as separators.
+    description: The branch within your department. The acronym must be lowercase with hyphens or underscores as separators.
     type: string
     maxLength: 63
-    pattern: '([a-z0-9\-]+)'
+    pattern: ^[a-z0-9_-]*$
   teamName:
     title: Team Name
-    description: The team name associated with the project. The name must be lowercase with hyphens as separators.
+    description: The team name associated with the project. The name must be lowercase with hyphens or underscores as separators.
     type: string
     maxLength: 63
-    pattern: '([a-z0-9\-\_]+)'
+    pattern: ^[a-z0-9_-]*$
   costCentre:
     title: Cost Centre
     type: string
     maxLength: 63
-    pattern: '([a-z0-9\-\_]+)'
+    pattern: ^[a-z0-9_-]*$
   costCentreName:
     title: Cost Centre Name
     description: The human-readable name for the Cost Centre.
     type: string
     maxLength: 63
-    pattern: '([a-z0-9\-\_]+)'
+    pattern: ^[a-z0-9_-]*$
   section32ManagerEmail:
     title: Section 32 Manager Email Address
     type: string

--- a/backstage/templates/project-create/template.parameters.project.yaml
+++ b/backstage/templates/project-create/template.parameters.project.yaml
@@ -9,6 +9,7 @@ properties:
     description: The resource display name. The name must be less than 26 characters. The name will be used to create a GCP Project named `<department>-<vanity-name>` in [HC-DMIA > DMIA-PHAC > SciencePlatform](https://console.cloud.google.com/cloud-resource-manager?folder=108494461414).
     type: string
     maxLength: 26
+    pattern: '([a-z0-9\-\_]+)'
   dataClassification:
     title: Data Classification
     description: The level of security for the project information and assets.

--- a/backstage/templates/project-create/template.parameters.project.yaml
+++ b/backstage/templates/project-create/template.parameters.project.yaml
@@ -9,7 +9,7 @@ properties:
     description: The resource display name. The name must be less than 26 characters. The name will be used to create a GCP Project named `<department>-<vanity-name>` in [HC-DMIA > DMIA-PHAC > SciencePlatform](https://console.cloud.google.com/cloud-resource-manager?folder=108494461414).
     type: string
     maxLength: 26
-    pattern: '([a-z0-9\-\_]+)'
+    pattern: /^[a-z0-9_-]$/
   dataClassification:
     title: Data Classification
     description: The level of security for the project information and assets.

--- a/backstage/templates/project-create/template.parameters.project.yaml
+++ b/backstage/templates/project-create/template.parameters.project.yaml
@@ -9,7 +9,7 @@ properties:
     description: The resource display name. The name must be less than 26 characters. The name will be used to create a GCP Project named `<department>-<vanity-name>` in [HC-DMIA > DMIA-PHAC > SciencePlatform](https://console.cloud.google.com/cloud-resource-manager?folder=108494461414).
     type: string
     maxLength: 26
-    pattern: ^[a-z0-9_-]$
+    pattern: ^[a-z0-9_-]*$
   dataClassification:
     title: Data Classification
     description: The level of security for the project information and assets.

--- a/backstage/templates/project-create/template.parameters.project.yaml
+++ b/backstage/templates/project-create/template.parameters.project.yaml
@@ -9,7 +9,7 @@ properties:
     description: The resource display name. The name must be less than 26 characters. The name will be used to create a GCP Project named `<department>-<vanity-name>` in [HC-DMIA > DMIA-PHAC > SciencePlatform](https://console.cloud.google.com/cloud-resource-manager?folder=108494461414).
     type: string
     maxLength: 26
-    pattern: /^[a-z0-9_-]$/
+    pattern: ^[a-z0-9_-]$
   dataClassification:
     title: Data Classification
     description: The level of security for the project information and assets.


### PR DESCRIPTION
Relates to #435 

Validation added to input fields related to labels. 

- max  length set to 63 if not already set
- regex to match lowercase a-z, 0-9, underscores, and hyphens

<img width="820" alt="Screenshot 2024-06-07 144845" src="https://github.com/PHACDataHub/sci-portal/assets/69818415/d79098fb-ed70-4f8b-a271-0d257385fd31">
<img width="827" alt="Screenshot 2024-06-07 144932" src="https://github.com/PHACDataHub/sci-portal/assets/69818415/8ef3beac-4161-43a2-9a9a-649257561d9b">
