### PR TITLE
Update the Rad Lab Terraform modules

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -127,6 +127,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
               'samantha.jones@phac-aspc.gc.ca',
               'alex.mcdonald@phac-aspc.gc.ca',
             ],
+
+            machineSize: 'small',
           },
         },
         mockDir,
@@ -216,6 +218,11 @@ describe('rad-lab-data-science-create: fetch:template', () => {
             - user:samantha.jones@gcp.hc-sc.gc.ca
             - user:alex.mcdonald@gcp.hc-sc.gc.ca
             - user:john.campbell@gcp.hc-sc.gc.ca
+
+          notebookEditors:
+            - jane.doe@gcp.hc-sc.gc.ca
+            - john.doe@gcp.hc-sc.gc.ca
+          machineSize: small
         ",
                 "kustomization.yaml": "---
         apiVersion: kustomize.config.k8s.io/v1beta1

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -127,6 +127,8 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
               'samantha.jones@phac-aspc.gc.ca',
               'alex.mcdonald@phac-aspc.gc.ca',
             ],
+
+            machineSize: 'small',
           },
         },
         mockDir,
@@ -216,6 +218,11 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
             - user:samantha.jones@gcp.hc-sc.gc.ca
             - user:alex.mcdonald@gcp.hc-sc.gc.ca
             - user:john.campbell@gcp.hc-sc.gc.ca
+
+          notebookEditors:
+            - jane.doe@gcp.hc-sc.gc.ca
+            - john.doe@gcp.hc-sc.gc.ca
+          machineSize: small
         ",
                 "kustomization.yaml": "---
         apiVersion: kustomize.config.k8s.io/v1beta1

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/claim.yaml.njk
@@ -26,3 +26,9 @@ spec:
     - user:${{viewer.email}}
   {%- endfor %}
   {%- endif %}
+
+  notebookEditors:
+  {%- for editor in values.editors %}
+    - ${{editor.email}}
+  {%- endfor %}
+  machineSize: ${{values.machineSize}}

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/claim.yaml.njk
@@ -26,3 +26,9 @@ spec:
     - user:${{viewer.email}}
   {%- endfor %}
   {%- endif %}
+
+  notebookEditors:
+  {%- for editor in values.editors %}
+    - ${{editor.email}}
+  {%- endfor %}
+  machineSize: ${{values.machineSize}}

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -28,8 +28,8 @@ spec:
               apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
               kind: Project
               metadata:
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
                 annotations:
                   cnrm.cloud.google.com/auto-create-network: "false"
                 labels: "TO BE PATCHED"
@@ -84,8 +84,8 @@ spec:
               apiVersion: iam.cnrm.cloud.google.com/v1beta1
               kind: IAMPolicy
               metadata:
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
               spec:
                 resourceRef:
                   kind: Project
@@ -106,8 +106,8 @@ spec:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
       patches:
         - fromFieldPath: "spec.projectName"
           toFieldPath: "metadata.name"
@@ -182,8 +182,8 @@ spec:
               apiVersion: billingbudgets.cnrm.cloud.google.com/v1beta1
               kind: BillingBudgetsBudget
               metadata:
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
               spec:
                 billingAccountRef:
                   external: "TO BE PATCHED"
@@ -212,13 +212,13 @@ spec:
                 allUpdatesRule:
                   schemaVersion: "1.0"
                   pubsubTopicRef:
-                      external: "projects/pht-01hsv4d2m0n/topics/science_portal_budget_alert"
+                    external: "projects/pht-01hsv4d2m0n/topics/science_portal_budget_alert"
           references:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
             - patchesFrom:
                 apiVersion: v1
                 kind: ConfigMap
@@ -314,8 +314,8 @@ spec:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
       patches:
         - fromFieldPath: "spec.projectName"
           toFieldPath: "metadata.name"
@@ -367,4 +367,3 @@ spec:
               string:
                 type: Format
                 fmt: "%s-api-dataplex"
-

--- a/root-sync/base/crossplane/rad-lab/data-science/composition-data-science.yaml
+++ b/root-sync/base/crossplane/rad-lab/data-science/composition-data-science.yaml
@@ -53,16 +53,16 @@ spec:
               apiVersion: tf.upbound.io/v1beta1
               kind: ProviderConfig
               metadata:
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
               spec:
                 configuration: "TO BE PATCHED"
           references:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
       patches:
         - fromFieldPath: "spec.projectName"
           toFieldPath: "metadata.name"
@@ -104,92 +104,65 @@ spec:
             name: kubernetes-provider
           forProvider:
             manifest:
-                apiVersion: tf.upbound.io/v1beta1
-                kind: Workspace
-                metadata:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: Workspace
+              metadata:
+                namespace: default
+                name: "TO BE PATCHED"
+              spec:
+                providerConfigRef:
                   name: "TO BE PATCHED"
-                  namespace: default
-                spec:
-                  providerConfigRef:
-                    name: "TO BE PATCHED"
-                  forProvider:
-                    module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/data-science?ref=main
-                    source: Remote
-                    vars:
-                      ##
-                      # Project
-                      ##
-                      - key: billing_account_id
-                        value: "TO BE PATCHED"
-                      - key: folder_id
-                        value: "TO BE PATCHED"
-                      - key: project_id_prefix
-                        value: "TO BE PATCHED"
+                forProvider:
+                  source: Remote
+                  module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/data-science?ref=main
+                  varmap:
+                    # Project:
+                    billing_account_id: "TO BE PATCHED"
+                    folder_id: "TO BE PATCHED"
+                    zone: "northamerica-northeast1-a"
+                    create_project: "false"
+                    project_id_prefix: "TO BE PATCHED"
 
+                    # Security Controls:
+                    set_domain_restricted_sharing_policy: "false"
+                    set_external_ip_policy: "false"
 
+                    # Notebook:
+                    create_usermanaged_notebook: "false"
+                    trusted_users: []
 
-                      ##
-                      # Permissions
-                      ##
+                    # (Option) Machine Type
+                    machine_type: "TO BE PATCHED"
 
-                      - key: create_project
-                        value: "false"
-                      - key: zone
-                        value: "northamerica-northeast1-a"
+                    # (Option) Deep Learning VM Image
+                    #
+                    # See https://cloud.google.com/deep-learning-vm/docs/images.
+                    # This may affect the machine type and GPU acceleration.
+                    # image_family: ""
 
-                      ##
-                      # Security Controls
-                      ##
-                      - key: set_domain_restricted_sharing_policy
-                        value: "false"
-                      - key: set_external_ip_policy
-                        value: "false"
+                    # (Option) GPU Acceleration
+                    enable_gpu_driver: "false"
+                    # gpu_accelerator_type: "false"
+                    # gpu_accelerator_core_count: "false"
 
-                      ##
-                      # (Option) Deep Learning VM Image
-                      #
-                      # See https://cloud.google.com/deep-learning-vm/docs/images.
-                      # This may affect the machine type and GPU acceleration.
-                      ##
-                      # - key: image_family
-                      #   value: ""
-
-                      ##
-                      # (Option) Machine Type
-                      ##
-                      - key: machine_type
-                        value: n1-standard-1
-
-                      ##
-                      # (Option) GPU Acceleration
-                      ##
-                      - key: enable_gpu_driver
-                        value: "false"
-                      # - key: gpu_accelerator_type
-                      #   value: "false"
-                      # - key: gpu_accelerator_core_count
-                      #   value: "false"
-
-                      - key: create_usermanaged_notebook
-                        value: "false"
           references:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
-            - dependsOn: # Custom ProviderConfig for storing terraform state
+                name: "TO BE PATCHED"
+            - dependsOn:  # Custom ProviderConfig for storing terraform state
                 apiVersion: tf.upbound.io/v1beta1
                 kind: ProviderConfig
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
             - patchesFrom:
                 apiVersion: v1
                 kind: ConfigMap
                 namespace: backstage
                 name: backstage-config
                 fieldPath: data.GCP_BILLING_ACCOUNT_ID
-              toFieldPath: "spec.forProvider.spec.forProvider.vars[0].value"
+              toFieldPath: "spec.forProvider.varmap.billing_account_id"
 
       patches:
         - fromFieldPath: "spec.projectName"
@@ -208,9 +181,19 @@ spec:
         - fromFieldPath: "spec.projectId"
           toFieldPath: "spec.forProvider.manifest.spec.providerConfigRef.name"
         - fromFieldPath: "spec.rootFolderId"
-          toFieldPath: "spec.forProvider.manifest.spec.forProvider.vars[1].value"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.folder_id"
         - fromFieldPath: "spec.projectId"
-          toFieldPath: "spec.forProvider.manifest.spec.forProvider.vars[2].value"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.project_id_prefix"
+        - fromFieldPath: "spec.notebookEditors"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.trusted_users"
+        - fromFieldPath: "spec.machineSize"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.machine_type"
+          transforms:
+            - type: map
+              map:
+                "small": "n1-standard-2"
+                "medium": "n1-standard-16"
+                "large": "n1-standard-64"
 
     - name: PROVIDER-CONFIG-USES-PROJECT
       base:

--- a/root-sync/base/crossplane/rad-lab/data-science/xrd-data-science.yaml
+++ b/root-sync/base/crossplane/rad-lab/data-science/xrd-data-science.yaml
@@ -24,7 +24,7 @@ spec:
             spec:
               type: object
               properties:
-                # Base Properties
+                # Project Properties
                 rootFolderId:
                   type: string
                 projectName:
@@ -74,8 +74,17 @@ spec:
                   type: array
                   items:
                     type: string
+
+                # Rad Lab Properties
+                notebookEditors:
+                  type: array
+                  items:
+                    type: string
+                machineSize:
+                  type: string
+                  enum: ["small", "medium", "large"]
               required:
-                # Base Properties
+                # Project Properties
                 - rootFolderId
                 - projectName
                 - projectId
@@ -83,3 +92,7 @@ spec:
                 - labels
                 - projectEditors
                 - projectViewers
+
+                # Rad Lab Properties
+                - notebookEditors
+                - machineSize

--- a/root-sync/base/crossplane/rad-lab/gen-ai/composition-gen-ai.yaml
+++ b/root-sync/base/crossplane/rad-lab/gen-ai/composition-gen-ai.yaml
@@ -53,16 +53,16 @@ spec:
               apiVersion: tf.upbound.io/v1beta1
               kind: ProviderConfig
               metadata:
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
               spec:
                 configuration: "TO BE PATCHED"
           references:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
       patches:
         - fromFieldPath: "spec.projectName"
           toFieldPath: "metadata.name"
@@ -104,92 +104,65 @@ spec:
             name: kubernetes-provider
           forProvider:
             manifest:
-                apiVersion: tf.upbound.io/v1beta1
-                kind: Workspace
-                metadata:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: Workspace
+              metadata:
+                namespace: default
+                name: "TO BE PATCHED"
+              spec:
+                providerConfigRef:
                   name: "TO BE PATCHED"
-                  namespace: default
-                spec:
-                  providerConfigRef:
-                    name: "TO BE PATCHED"
-                  forProvider:
-                    module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/gen-ai?ref=main
-                    source: Remote
-                    vars:
-                      ##
-                      # Project
-                      ##
-                      - key: billing_account_id
-                        value: "TO BE PATCHED"
-                      - key: folder_id
-                        value: "TO BE PATCHED"
-                      - key: project_id_prefix
-                        value: "TO BE PATCHED"
+                forProvider:
+                  source: Remote
+                  module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/gen-ai?ref=main
+                  varmap:
+                    # Project:
+                    billing_account_id: "TO BE PATCHED"
+                    folder_id: "TO BE PATCHED"
+                    zone: "northamerica-northeast1-a"
+                    create_project: "false"
+                    project_id_prefix: "TO BE PATCHED"
 
+                    # Security Controls:
+                    set_domain_restricted_sharing_policy: "false"
+                    set_external_ip_policy: "false"
 
+                    # Notebook:
+                    create_usermanaged_notebook: "false"
+                    trusted_users: []
 
-                      ##
-                      # Permissions
-                      ##
+                    # (Option) Machine Type
+                    machine_type: "TO BE PATCHED"
 
-                      - key: create_project
-                        value: "false"
-                      - key: zone
-                        value: "northamerica-northeast1-a"
+                    # (Option) Deep Learning VM Image
+                    #
+                    # See https://cloud.google.com/deep-learning-vm/docs/images.
+                    # This may affect the machine type and GPU acceleration.
+                    # image_family: ""
 
-                      ##
-                      # Security Controls
-                      ##
-                      - key: set_domain_restricted_sharing_policy
-                        value: "false"
-                      - key: set_external_ip_policy
-                        value: "false"
+                    # (Option) GPU Acceleration
+                    enable_gpu_driver: "false"
+                    # gpu_accelerator_type: "false"
+                    # gpu_accelerator_core_count: "false"
 
-                      ##
-                      # (Option) Deep Learning VM Image
-                      #
-                      # See https://cloud.google.com/deep-learning-vm/docs/images.
-                      # This may affect the machine type and GPU acceleration.
-                      ##
-                      # - key: image_family
-                      #   value: ""
-
-                      ##
-                      # (Option) Machine Type
-                      ##
-                      - key: machine_type
-                        value: n1-standard-8
-
-                      ##
-                      # (Option) GPU Acceleration
-                      ##
-                      - key: enable_gpu_driver
-                        value: "false"
-                      # - key: gpu_accelerator_type
-                      #   value: "false"
-                      # - key: gpu_accelerator_core_count
-                      #   value: "false"
-
-                      - key: create_usermanaged_notebook
-                        value: "false"
           references:
             - dependsOn:
                 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
                 kind: Project
-                name: "TO BE PATCHED"
                 namespace: default
-            - dependsOn: # Custom ProviderConfig for storing terraform state
+                name: "TO BE PATCHED"
+            - dependsOn:  # Custom ProviderConfig for storing terraform state
                 apiVersion: tf.upbound.io/v1beta1
                 kind: ProviderConfig
-                name: "TO BE PATCHED"
                 namespace: default
+                name: "TO BE PATCHED"
             - patchesFrom:
                 apiVersion: v1
                 kind: ConfigMap
                 namespace: backstage
                 name: backstage-config
                 fieldPath: data.GCP_BILLING_ACCOUNT_ID
-              toFieldPath: "spec.forProvider.spec.forProvider.vars[0].value"
+              toFieldPath: "spec.forProvider.varmap.billing_account_id"
 
       patches:
         - fromFieldPath: "spec.projectName"
@@ -208,9 +181,19 @@ spec:
         - fromFieldPath: "spec.projectId"
           toFieldPath: "spec.forProvider.manifest.spec.providerConfigRef.name"
         - fromFieldPath: "spec.rootFolderId"
-          toFieldPath: "spec.forProvider.manifest.spec.forProvider.vars[1].value"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.folder_id"
         - fromFieldPath: "spec.projectId"
-          toFieldPath: "spec.forProvider.manifest.spec.forProvider.vars[2].value"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.project_id_prefix"
+        - fromFieldPath: "spec.notebookEditors"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.trusted_users"
+        - fromFieldPath: "spec.machineSize"
+          toFieldPath: "spec.forProvider.manifest.spec.forProvider.varmap.machine_type"
+          transforms:
+            - type: map
+              map:
+                "small": "n1-standard-2"
+                "medium": "n1-standard-16"
+                "large": "n1-standard-64"
 
     - name: PROVIDER-CONFIG-USES-PROJECT
       base:

--- a/root-sync/base/crossplane/rad-lab/gen-ai/xrd-gen-ai.yaml
+++ b/root-sync/base/crossplane/rad-lab/gen-ai/xrd-gen-ai.yaml
@@ -24,7 +24,7 @@ spec:
             spec:
               type: object
               properties:
-                # Base Properties
+                # Project Properties
                 rootFolderId:
                   type: string
                 projectName:
@@ -74,8 +74,17 @@ spec:
                   type: array
                   items:
                     type: string
+
+                # Rad Lab Properties
+                notebookEditors:
+                  type: array
+                  items:
+                    type: string
+                machineSize:
+                  type: string
+                  enum: ["small", "medium", "large"]
               required:
-                # Base Properties
+                # Project Properties
                 - rootFolderId
                 - projectName
                 - projectId
@@ -83,3 +92,7 @@ spec:
                 - labels
                 - projectEditors
                 - projectViewers
+
+                # Rad Lab Properties
+                - notebookEditors
+                - machineSize

--- a/tests/templates/rad-lab-data-science/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-data-science/chainsaw-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: project-claim
+  name: rad-lab-data-science-claim
 spec:
   template: true
   bindings:
@@ -47,11 +47,11 @@ spec:
 
         # Act
 
-        - description: Apply a ProjectClaim
+        - description: Apply a RadLabDataScienceClaim
           apply:
             resource:
               apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
-              kind: ProjectClaim
+              kind: RadLabDataScienceClaim
               metadata:
                 namespace: default
                 name: (join('-', [$projectName, $requestId]))
@@ -76,14 +76,18 @@ spec:
                   - user:sean.poulter@focisolutions.com
                   - user:sean.poulter@gcp.hc-sc.gc.ca
 
+                notebookEditors:
+                  - sean.poulter@focisolutions.com
+                machineSize: medium
+
         # Assert
 
-        - description: Assert the ProjectClaim has been created
+        - description: Assert the RadLabDataScienceClaim has been created
           assert:
             timeout: 5m
             resource:
               apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
-              kind: ProjectClaim
+              kind: RadLabDataScienceClaim
               metadata:
                 namespace: default
                 name: (join('-', [$projectName, $requestId]))
@@ -183,4 +187,46 @@ spec:
                 resourceID: dataplex.googleapis.com
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
+                  - status: "True"
+
+        - description: Assert the Terraform ProviderConfig has been created
+          assert:
+            resource:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: ProviderConfig
+              metadata:
+                name: ($projectId)
+
+        - description: Assert the Terraform Workspace has been created
+          assert:
+            timeout: 10m
+            resource:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: Workspace
+              metadata:
+                # namespace: default
+                name: ($projectId)
+              spec:
+                providerConfigRef:
+                  name: ($projectId)
+                forProvider:
+                  source: Remote
+                  module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/data-science?ref=main
+                  varmap:
+                    folder_id: ($folderId)
+                    project_id_prefix: ($projectId)
+                    trusted_users:
+                      - sean.poulter@focisolutions.com
+                    machine_type: n1-standard-16
+              status:
+                atProvider:
+                  outputs:
+                    notebooks_googlemanaged_urls:
+                    - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
+                    user_scripts_bucket_uri: (concat('https://www.googleapis.com/storage/v1/b/user-scripts-', $projectId))
+
+                # conditions:
+                (conditions[?type == 'Synced']):
+                  - status: "True"
+                (conditions[?type == 'Ready']):
                   - status: "True"

--- a/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: project-claim
+  name: rad-lab-gen-ai-claim
 spec:
   template: true
   bindings:
@@ -47,11 +47,11 @@ spec:
 
         # Act
 
-        - description: Apply a ProjectClaim
+        - description: Apply a RadLabGenAIClaim
           apply:
             resource:
               apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
-              kind: ProjectClaim
+              kind: RadLabGenAIClaim
               metadata:
                 namespace: default
                 name: (join('-', [$projectName, $requestId]))
@@ -76,14 +76,18 @@ spec:
                   - user:sean.poulter@focisolutions.com
                   - user:sean.poulter@gcp.hc-sc.gc.ca
 
+                notebookEditors:
+                  - sean.poulter@focisolutions.com
+                machineSize: medium
+
         # Assert
 
-        - description: Assert the ProjectClaim has been created
+        - description: Assert the RadLabGenAIClaim has been created
           assert:
             timeout: 5m
             resource:
               apiVersion: data-science-portal.phac-aspc.gc.ca/v1alpha1
-              kind: ProjectClaim
+              kind: RadLabGenAIClaim
               metadata:
                 namespace: default
                 name: (join('-', [$projectName, $requestId]))
@@ -183,4 +187,46 @@ spec:
                 resourceID: dataplex.googleapis.com
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
+                  - status: "True"
+
+        - description: Assert the Terraform ProviderConfig has been created
+          assert:
+            resource:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: ProviderConfig
+              metadata:
+                name: ($projectId)
+
+        - description: Assert the Terraform Workspace has been created
+          assert:
+            timeout: 10m
+            resource:
+              apiVersion: tf.upbound.io/v1beta1
+              kind: Workspace
+              metadata:
+                # namespace: default
+                name: ($projectId)
+              spec:
+                providerConfigRef:
+                  name: ($projectId)
+                forProvider:
+                  source: Remote
+                  module: git::https://github.com/PHACDataHub/sci-portal.git//templates/rad-lab/gen-ai?ref=main
+                  varmap:
+                    folder_id: ($folderId)
+                    project_id_prefix: ($projectId)
+                    trusted_users:
+                      - sean.poulter@focisolutions.com
+                    machine_type: n1-standard-16
+              status:
+                atProvider:
+                  outputs:
+                    workbench_googlemanaged_urls:
+                    - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
+                    user_scripts_bucket_uri: (concat('https://www.googleapis.com/storage/v1/b/user-scripts-', $projectId))
+
+                # conditions:
+                (conditions[?type == 'Synced']):
+                  - status: "True"
+                (conditions[?type == 'Ready']):
                   - status: "True"


### PR DESCRIPTION
This PR relates to #69 and #439.

### Propsed Changes

In order to refactor and add features with confidence:

- Add `chainsaw` tests for the Rad Lab modules to refactor with confidence
- Update the `chainsaw` test for the Project to check status on remaining resources managed by Config Connector

In order of appearance in the diff:

- Set the `machine_type` and `trusted_users` in the Rad Lab Terraform modules
- Move `namespace` before `name` in Kubernetes manifests
- Switch the Crossplane Terraform Workspace from `vars` to `varmap`
- Fix the `billing_account_id` patch
- Set the `trusted_users` and `machine_type`

### Test Plan

- Tested with `chainsaw`
- Tested locally
  -  The properties are added to the claim: https://github.com/PHACDataHub/sci-portal-users/pull/29/files#diff-10135e87be5f63a30c2803c7ce75a1eb4588a2ee10b1e9bdd8a36e077b17dce3R28-R33
  - Config Sync syncs
  - The module deploys and the link to the Managed Workbooks works as expected
    https://backstage.alpha.phac-aspc.gc.ca/catalog/default/component/phx-01j006223h0
    <img width="2055" alt="image" src="https://github.com/PHACDataHub/sci-portal/assets/98067886/c631c75d-bcee-40ee-9af7-460b4fd3b77b">
