### PR TITLE
Improve the budget alert notifications

### DIFF
--- a/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/project-create.test.ts
@@ -161,7 +161,8 @@ describe('project-create: fetch:template', () => {
           annotations:
             backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/project-create
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
         spec:
           type: project
@@ -174,7 +175,8 @@ describe('project-create: fetch:template', () => {
           name: <project-id>-editors
           title: <project-name> Editors
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []
@@ -189,7 +191,8 @@ describe('project-create: fetch:template', () => {
           name: <project-id>-viewers
           title: <project-name> Viewers
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-data-science-create.test.ts
@@ -148,7 +148,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           annotations:
             backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/rad-lab-data-science-create
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
           links:
             - title: View Managed Notebooks on Google Cloud
@@ -165,7 +166,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           name: <project-id>-editors
           title: <project-name> Editors
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []
@@ -180,7 +182,8 @@ describe('rad-lab-data-science-create: fetch:template', () => {
           name: <project-id>-viewers
           title: <project-name> Viewers
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []

--- a/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
+++ b/backstage/packages/backend/src/plugins/scaffolder/templates/rad-lab-gen-ai-create.test.ts
@@ -148,7 +148,8 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           annotations:
             backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/DMIA-PHAC/SciencePlatform/<project-id>/
             backstage.io/source-template: template:default/rad-lab-gen-ai-create
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
             data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: jane.doe@gcp.hc-sc.gc.ca,samantha.jones@phac-aspc.gc.ca,alex.mcdonald@phac-aspc.gc.ca
           links:
             - title: View Managed Notebooks on Google Cloud
@@ -165,7 +166,8 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           name: <project-id>-editors
           title: <project-name> Editors
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []
@@ -180,7 +182,8 @@ describe('rad-lab-gen-ai-create: fetch:template', () => {
           name: <project-id>-viewers
           title: <project-name> Viewers
           annotations:
-            cloud.google.com/project: <project-id>
+            cloud.google.com/project-id: <project-id>
+            cloud.google.com/project-name: <project-name>
         spec:
           type: team
           children: []

--- a/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/project-create/pull-request-changes/catalog-info.yaml.njk
@@ -7,7 +7,8 @@ metadata:
   annotations:
     backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/project-create
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}
 spec:
   type: project
@@ -20,7 +21,8 @@ metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []
@@ -36,7 +38,8 @@ metadata:
   name: ${{values.projectId}}-viewers
   title: ${{values.projectName}} Viewers
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []

--- a/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-data-science-create/pull-request-changes/catalog-info.yaml.njk
@@ -7,7 +7,8 @@ metadata:
   annotations:
     backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/rad-lab-data-science-create
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}
   links:
     - title: View Managed Notebooks on Google Cloud
@@ -24,7 +25,8 @@ metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []
@@ -40,7 +42,8 @@ metadata:
   name: ${{values.projectId}}-viewers
   title: ${{values.projectName}} Viewers
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []

--- a/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
+++ b/backstage/templates/rad-lab-gen-ai-create/pull-request-changes/catalog-info.yaml.njk
@@ -7,7 +7,8 @@ metadata:
   annotations:
     backstage.io/source-location: https://github.com/PHACDevHub/sci-portal-users/${{values.sourceLocation}}
     backstage.io/source-template: template:default/rad-lab-gen-ai-create
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
     data-science-portal.phac-aspc.gc.ca/budget-alert-recipients: ${{values.budgetAlertEmailRecipients | join(',')}}
   links:
     - title: View Managed Notebooks on Google Cloud
@@ -24,7 +25,8 @@ metadata:
   name: ${{values.projectId}}-editors
   title: ${{values.projectName}} Editors
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []
@@ -40,7 +42,8 @@ metadata:
   name: ${{values.projectId}}-viewers
   title: ${{values.projectName}} Viewers
   annotations:
-    cloud.google.com/project: ${{values.projectId}}
+    cloud.google.com/project-id: ${{values.projectId}}
+    cloud.google.com/project-name: ${{values.projectName}}
 spec:
   type: team
   children: []

--- a/budget-alerts/src/backstage.js
+++ b/budget-alerts/src/backstage.js
@@ -12,7 +12,7 @@ async function getBudgetAlertRecipients(projectId) {
   const { BACKSTAGE_BUDGET_ALERT_EVENTS_TOKEN, BACKSTAGE_URI } = process.env;
 
   const params = new URLSearchParams({
-    filter: `metadata.annotations.cloud.google.com/project=${projectId}`,
+    filter: `metadata.annotations.cloud.google.com/project-id=${projectId}`,
     fields: `metadata.annotations.${BUDGET_ALERT_RECIPIENTS_ANNOTATION}`,
   });
   const url = `${BACKSTAGE_URI}/api/catalog/entities/by-query?${params}`;
@@ -26,7 +26,7 @@ async function getBudgetAlertRecipients(projectId) {
 
   if (!response.ok) {
     throw new Error(
-      `Status:${response.status} - Failed to fetch project data for project ${projectId}`,
+      `HTTP${response.status} ${response.statusText}: Failed to fetch data from Backstage for project ID ${projectId}`,
     );
   }
 

--- a/budget-alerts/src/cloud_events.js
+++ b/budget-alerts/src/cloud_events.js
@@ -29,11 +29,7 @@ function parseMessage(cloudEvent) {
     return undefined;
   }
 
-  const message = JSON.parse(Buffer.from(encodedMessage, 'base64').toString());
-  if (!('alertThresholdExceeded' in message)) {
-    message.alertThresholdExceeded = 0;
-  }
-  return message;
+  return JSON.parse(Buffer.from(encodedMessage, 'base64').toString());
 }
 
 module.exports = { parseMessage };

--- a/budget-alerts/src/index.js
+++ b/budget-alerts/src/index.js
@@ -29,7 +29,7 @@ async function sendBudgetAlerts(cloudEvent) {
   }
 
   try {
-    const recipients = await getBudgetAlertRecipients(message.budgetDisplayName);
+    const recipients = await getBudgetAlertRecipients(message.projectId);
     if (!recipients) {
       console.log('Existing with no recipients to notify');
       return;

--- a/budget-alerts/src/index.js
+++ b/budget-alerts/src/index.js
@@ -60,7 +60,7 @@ async function sendBudgetAlerts(cloudEvent) {
       project_id: projectId,
 
       // Transform the threshold from 0 to 1 to a percentage.
-      threshold: (message.alertThresholdExceeded * 100).toFixed(1),
+      threshold: (message.alertThresholdExceeded * 100).toFixed(0),
 
       // Costs accrued.
       amount: message.costAmount,

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -245,7 +245,7 @@ spec:
                 fmt: "budget-%s"
         - fromFieldPath: "spec.budget"
           toFieldPath: "spec.forProvider.manifest.spec.amount.specifiedAmount.units"
-        - fromFieldPath: "spec.projectName"
+        - fromFieldPath: "spec.projectId"
           toFieldPath: "spec.forProvider.manifest.spec.displayName"
           transforms:
             - type: string

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -287,11 +287,6 @@ spec:
           toFieldPath: "spec.forProvider.manifest.spec.amount.specifiedAmount.units"
         - fromFieldPath: "spec.projectId"
           toFieldPath: "spec.forProvider.manifest.spec.displayName"
-          transforms:
-            - type: string
-              string:
-                type: Format
-                fmt: "budget-%s"
         - fromFieldPath: "spec.projectName"
           toFieldPath: "spec.forProvider.manifest.spec.budgetFilter.projects[0].name"
       readinessChecks:

--- a/root-sync/base/crossplane/project/composition-project.yaml
+++ b/root-sync/base/crossplane/project/composition-project.yaml
@@ -209,6 +209,46 @@ spec:
                     spendBasis: "CURRENT_SPEND"
                   - thresholdPercent: 1.00
                     spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.01
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.02
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.03
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.04
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.05
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.06
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.07
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.08
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.09
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.10
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.11
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.12
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.13
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.14
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.15
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.16
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.17
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.18
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.19
+                    spendBasis: "CURRENT_SPEND"
+                  - thresholdPercent: 1.20
+                    spendBasis: "CURRENT_SPEND"
                 allUpdatesRule:
                   schemaVersion: "1.0"
                   pubsubTopicRef:

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
               kind: ProjectClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               spec:
                 rootFolderId: ($folderId)
                 projectName: ($projectName)
@@ -86,7 +86,7 @@ spec:
               kind: ProjectClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               status:
                 (conditions[?type == 'Synced']):
                   - status: "True"
@@ -130,7 +130,7 @@ spec:
               kind: IAMPolicy
               metadata:
                 namespace: default
-                name: (join('-', ['iampolicy', $projectName]))
+                name: (join('', ['iampolicy-', $projectName]))
               spec:
                 resourceRef:
                   kind: Project
@@ -154,7 +154,7 @@ spec:
               kind: BillingBudgetsBudget
               metadata:
                 namespace: default
-                name: (join('-', ['budget', $projectName]))
+                name: (join('', ['budget-', $projectName]))
               spec:
                 amount:
                   specifiedAmount:
@@ -164,7 +164,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('-', ['budget', $projectName]))
+                displayName: (join('', ['budget-', $projectId]))
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"
@@ -176,7 +176,7 @@ spec:
               kind: Service
               metadata:
                 namespace: default
-                name: (join('-', ['dataplex', $projectName]))
+                name: (join('', ['dataplex-', $projectName]))
               spec:
                 projectRef:
                   name: ($projectName)

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -164,7 +164,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('', ['budget-', $projectId]))
+                displayName: ($projectId)
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"

--- a/tests/templates/rad-lab-data-science/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-data-science/chainsaw-test.yaml
@@ -168,7 +168,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('', ['budget-', $projectId]))
+                displayName: ($projectId)
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"

--- a/tests/templates/rad-lab-data-science/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-data-science/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
               kind: RadLabDataScienceClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               spec:
                 rootFolderId: ($folderId)
                 projectName: ($projectName)
@@ -90,7 +90,7 @@ spec:
               kind: RadLabDataScienceClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               status:
                 (conditions[?type == 'Synced']):
                   - status: "True"
@@ -134,7 +134,7 @@ spec:
               kind: IAMPolicy
               metadata:
                 namespace: default
-                name: (join('-', ['iampolicy', $projectName]))
+                name: (join('', ['iampolicy-', $projectName]))
               spec:
                 resourceRef:
                   kind: Project
@@ -158,7 +158,7 @@ spec:
               kind: BillingBudgetsBudget
               metadata:
                 namespace: default
-                name: (join('-', ['budget', $projectName]))
+                name: (join('', ['budget-', $projectName]))
               spec:
                 amount:
                   specifiedAmount:
@@ -168,7 +168,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('-', ['budget', $projectName]))
+                displayName: (join('', ['budget-', $projectId]))
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"
@@ -180,7 +180,7 @@ spec:
               kind: Service
               metadata:
                 namespace: default
-                name: (join('-', ['dataplex', $projectName]))
+                name: (join('', ['dataplex-', $projectName]))
               spec:
                 projectRef:
                   name: ($projectName)
@@ -222,7 +222,7 @@ spec:
                 atProvider:
                   outputs:
                     notebooks_googlemanaged_urls:
-                    - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
+                      - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
                     user_scripts_bucket_uri: (concat('https://www.googleapis.com/storage/v1/b/user-scripts-', $projectId))
 
                 # conditions:

--- a/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
@@ -168,7 +168,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('', ['budget-', $projectId]))
+                displayName: ($projectId)
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"

--- a/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
               kind: RadLabGenAIClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               spec:
                 rootFolderId: ($folderId)
                 projectName: ($projectName)
@@ -90,7 +90,7 @@ spec:
               kind: RadLabGenAIClaim
               metadata:
                 namespace: default
-                name: (join('-', [$projectName, $requestId]))
+                name: (join('', [$projectName, '-', $requestId]))
               status:
                 (conditions[?type == 'Synced']):
                   - status: "True"
@@ -134,7 +134,7 @@ spec:
               kind: IAMPolicy
               metadata:
                 namespace: default
-                name: (join('-', ['iampolicy', $projectName]))
+                name: (join('', ['iampolicy-', $projectName]))
               spec:
                 resourceRef:
                   kind: Project
@@ -158,7 +158,7 @@ spec:
               kind: BillingBudgetsBudget
               metadata:
                 namespace: default
-                name: (join('-', ['budget', $projectName]))
+                name: (join('', ['budget-', $projectName]))
               spec:
                 amount:
                   specifiedAmount:
@@ -168,7 +168,7 @@ spec:
                   calendarPeriod: YEAR
                   projects:
                     - name: ($projectName)
-                displayName: (join('-', ['budget', $projectName]))
+                displayName: (join('', ['budget-', $projectId]))
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"
@@ -180,7 +180,7 @@ spec:
               kind: Service
               metadata:
                 namespace: default
-                name: (join('-', ['dataplex', $projectName]))
+                name: (join('', ['dataplex-', $projectName]))
               spec:
                 projectRef:
                   name: ($projectName)
@@ -222,7 +222,7 @@ spec:
                 atProvider:
                   outputs:
                     workbench_googlemanaged_urls:
-                    - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
+                      - (concat('https://console.cloud.google.com/vertex-ai/workbench/managed?project=', $projectId))
                     user_scripts_bucket_uri: (concat('https://www.googleapis.com/storage/v1/b/user-scripts-', $projectId))
 
                 # conditions:


### PR DESCRIPTION
### Proposed Changes

- Set the project ID and name in the Backstage annotations
- Query for the budget alert recipients by the `project-id`
- Add more logging to the Cloud Function
- Add alerts for every percentage from 100-120%
- Refactor `join('-',` to `join('',` in the `chainsaw` tests
