### PR TITLE
Remove focisolutions.com as an allowed domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ BACKSTAGE_URI=https://backstage.alpha.phac-aspc.gc.ca
 # Backstage Auth
 AUTH_GOOGLE_CLIENT_ID=
 AUTH_GOOGLE_CLIENT_SECRET=
-AUTH_GOOGLE_ALLOWED_DOMAINS=gcp.hc-sc.gc.ca,focisolutions.com
+AUTH_GOOGLE_ALLOWED_DOMAINS=gcp.hc-sc.gc.ca
 
 # Backstage Templates
 GITOPS_REPO_OWNER=PHACDataHub

--- a/backstage/templates/add-user/template.yaml
+++ b/backstage/templates/add-user/template.yaml
@@ -54,12 +54,12 @@ spec:
       name: Create User
       action: catalog:write
       input:
-        filePath: ${{parameters.email | replace(r/@(focisolutions.com|gcp.hc-sc.hc.ca)/, "")}}.yaml
+        filePath: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}.yaml
         entity:
           apiVersion: backstage.io/v1alpha1
           kind: User
           metadata:
-            name: ${{parameters.email | replace(r/@(focisolutions.com|gcp.hc-sc.hc.ca)/, "")}}
+            name: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}
           spec:
             profile:
               displayName: '${{parameters.displayName}}'
@@ -83,7 +83,7 @@ spec:
       if: ${{ parameters.pullRequestAction != 'Diff Only' }}
       input:
         repoUrl: github.com?owner=PHACDataHub&repo=sci-portal-users
-        branchName: ${{parameters.email | replace(r/@(focisolutions.com|gcp.hc-sc.hc.ca)/, "")}}
+        branchName: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}
         title: Add ${{parameters.email}}
         description: This PR adds a `User` for ${{parameters.email}}.
         reviewers:

--- a/backstage/templates/add-user/template.yaml
+++ b/backstage/templates/add-user/template.yaml
@@ -54,12 +54,12 @@ spec:
       name: Create User
       action: catalog:write
       input:
-        filePath: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}.yaml
+        filePath: ${{parameters.email | replace(r/@gcp.hc-sc.gc.ca/, "")}}.yaml
         entity:
           apiVersion: backstage.io/v1alpha1
           kind: User
           metadata:
-            name: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}
+            name: ${{parameters.email | replace(r/@gcp.hc-sc.gc.ca/, "")}}
           spec:
             profile:
               displayName: '${{parameters.displayName}}'
@@ -83,7 +83,7 @@ spec:
       if: ${{ parameters.pullRequestAction != 'Diff Only' }}
       input:
         repoUrl: github.com?owner=PHACDataHub&repo=sci-portal-users
-        branchName: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}
+        branchName: ${{parameters.email | replace(r/@gcp.hc-sc.gc.ca/, "")}}
         title: Add ${{parameters.email}}
         description: This PR adds a `User` for ${{parameters.email}}.
         reviewers:

--- a/backstage/templates/add-user/template.yaml
+++ b/backstage/templates/add-user/template.yaml
@@ -54,12 +54,12 @@ spec:
       name: Create User
       action: catalog:write
       input:
-        filePath: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}.yaml
+        filePath: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}.yaml
         entity:
           apiVersion: backstage.io/v1alpha1
           kind: User
           metadata:
-            name: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}
+            name: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}
           spec:
             profile:
               displayName: '${{parameters.displayName}}'
@@ -83,7 +83,7 @@ spec:
       if: ${{ parameters.pullRequestAction != 'Diff Only' }}
       input:
         repoUrl: github.com?owner=PHACDataHub&repo=sci-portal-users
-        branchName: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca$/, "")}}
+        branchName: ${{parameters.email | replace(r/@gcp.hc-sc.hc.ca/, "")}}
         title: Add ${{parameters.email}}
         description: This PR adds a `User` for ${{parameters.email}}.
         reviewers:

--- a/tests/templates/project/chainsaw-test.yaml
+++ b/tests/templates/project/chainsaw-test.yaml
@@ -71,10 +71,11 @@ spec:
                   team-name: 'team-abc'
                   vanity-name: '($projectName)'
                 projectEditors:
-                  - user:sean.poulter@focisolutions.com
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
                 projectViewers:
-                  - user:sean.poulter@focisolutions.com
-                  - user:sean.poulter@gcp.hc-sc.gc.ca
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
 
         # Assert
 
@@ -138,11 +139,12 @@ spec:
                 bindings:
                   - role: roles/editor
                     members:
-                      - user:sean.poulter@focisolutions.com
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
                   - role: roles/viewer
                     members:
-                      - user:sean.poulter@focisolutions.com
-                      - user:sean.poulter@gcp.hc-sc.gc.ca
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"

--- a/tests/templates/rad-lab-data-science/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-data-science/chainsaw-test.yaml
@@ -71,13 +71,15 @@ spec:
                   team-name: 'team-abc'
                   vanity-name: '($projectName)'
                 projectEditors:
-                  - user:sean.poulter@focisolutions.com
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
                 projectViewers:
-                  - user:sean.poulter@focisolutions.com
-                  - user:sean.poulter@gcp.hc-sc.gc.ca
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
 
                 notebookEditors:
-                  - sean.poulter@focisolutions.com
+                  - keith.young@gcp.hc-sc.gc.ca
+                  - vedant.thapa@gcp.hc-sc.gc.ca
                 machineSize: medium
 
         # Assert
@@ -142,11 +144,12 @@ spec:
                 bindings:
                   - role: roles/editor
                     members:
-                      - user:sean.poulter@focisolutions.com
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
                   - role: roles/viewer
                     members:
-                      - user:sean.poulter@focisolutions.com
-                      - user:sean.poulter@gcp.hc-sc.gc.ca
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"
@@ -216,7 +219,8 @@ spec:
                     folder_id: ($folderId)
                     project_id_prefix: ($projectId)
                     trusted_users:
-                      - sean.poulter@focisolutions.com
+                      - keith.young@gcp.hc-sc.gc.ca
+                      - vedant.thapa@gcp.hc-sc.gc.ca
                     machine_type: n1-standard-16
               status:
                 atProvider:

--- a/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
+++ b/tests/templates/rad-lab-gen-ai/chainsaw-test.yaml
@@ -71,13 +71,15 @@ spec:
                   team-name: 'team-abc'
                   vanity-name: '($projectName)'
                 projectEditors:
-                  - user:sean.poulter@focisolutions.com
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
                 projectViewers:
-                  - user:sean.poulter@focisolutions.com
-                  - user:sean.poulter@gcp.hc-sc.gc.ca
+                  - user:keith.young@gcp.hc-sc.gc.ca
+                  - user:vedant.thapa@gcp.hc-sc.gc.ca
 
                 notebookEditors:
-                  - sean.poulter@focisolutions.com
+                  - keith.young@gcp.hc-sc.gc.ca
+                  - vedant.thapa@gcp.hc-sc.gc.ca
                 machineSize: medium
 
         # Assert
@@ -142,11 +144,12 @@ spec:
                 bindings:
                   - role: roles/editor
                     members:
-                      - user:sean.poulter@focisolutions.com
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
                   - role: roles/viewer
                     members:
-                      - user:sean.poulter@focisolutions.com
-                      - user:sean.poulter@gcp.hc-sc.gc.ca
+                      - user:keith.young@gcp.hc-sc.gc.ca
+                      - user:vedant.thapa@gcp.hc-sc.gc.ca
               status:
                 (conditions[?type == 'Ready' && reason == 'UpToDate']):
                   - status: "True"
@@ -216,7 +219,8 @@ spec:
                     folder_id: ($folderId)
                     project_id_prefix: ($projectId)
                     trusted_users:
-                      - sean.poulter@focisolutions.com
+                      - keith.young@gcp.hc-sc.gc.ca
+                      - vedant.thapa@gcp.hc-sc.gc.ca
                     machine_type: n1-standard-16
               status:
                 atProvider:


### PR DESCRIPTION
This is a draft PR for #434. It handles all the expected changes except to the OAuth screen.

> [!Warning]
> Do not merge until Foci rolls off.

### Proposed Changes

- Removes focisolutions.com as an allowed domain
- Changes the users in the `chainsaw` tests to be users that exist in the org.

### Important Notes

> [!Important]
> Update `AUTH_GOOGLE_ALLOWED_DOMAINS` in the `backstage-config` ConfigMap.

### Test Plan

The changes to the Add User template have been tested locally:
https://github.com/PHACDataHub/sci-portal-users/pull/32
