### PR TITLE
Fix build error

### DIFF
--- a/.github/workflows/pr-root-sync.yaml
+++ b/.github/workflows/pr-root-sync.yaml
@@ -64,6 +64,7 @@ jobs:
           kustomize build . \
           | kubeconform \
             -verbose -strict \
+            -skip ConfigConnector \
             -ignore-missing-schemas \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/root-sync/README.md
+++ b/root-sync/README.md
@@ -1,6 +1,6 @@
 ## root-sync
 
-This Module contains the Config Sync manifests to manage root-level resources in the Kubernetes cluster. Config Sync will install resources defined in this directory.
+This directory contains the Config Sync manifests to manage root-level resources in the Kubernetes cluster. Config Sync will install resources defined in this directory.
 
 ### Setup
 


### PR DESCRIPTION
### Proposed Changes

Attempt to fix the unexpected schema validation error from https://github.com/PHACDataHub/sci-portal/actions/runs/9622232870/:

```
stdin - ConfigConnector configconnector.core.cnrm.cloud.google.com is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/core.cnrm.cloud.google.com/configconnector_v1beta1.json#/properties/spec/anyOf/0/oneOf/0/required: missing properties: 'credentialSecretName'
```
