### PR TITLE
Wait for and terminate the istio-proxy container

### DIFF
--- a/root-sync/base/budget-alerts/calculate-percent-budget-daily.yaml
+++ b/root-sync/base/budget-alerts/calculate-percent-budget-daily.yaml
@@ -16,7 +16,17 @@ spec:
             - name: curl
               image: curlimages/curl:8.8.0
               imagePullPolicy: IfNotPresent
-              command: ['curl', '-v', '--request', 'POST', '-H', 'Authorization: Bearer $(BACKSTAGE_BUDGET_ALERT_EVENTS_TOKEN)', '$(BASE_URL)/api/budget-usage/sync']
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+                # We need to wait for the istio-proxy container to be healthy to make network requests.
+                while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done
+
+                # We need to configure the istio-proxy container to stop when the job is done.
+                # A better solution is becoming available. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/.
+                trap "curl --max-time 2 -s -f -XPOST http://127.0.0.1:15020/quitquitquit" EXIT
+
+                curl -v --request POST -H "Authorization: Bearer $(BACKSTAGE_BUDGET_ALERT_EVENTS_TOKEN)" "$(BASE_URL)/api/budget-usage/sync"
               env:
                 - name: BASE_URL
                   value: http://backstage.backstage.svc.cluster.local:7007


### PR DESCRIPTION
### Proposed Changes

- Wait for `istio-proxy` so the network request can reach the `backstage` pod
- Terminate the `istio-proxy` when the network request completes so it doesn't run forever
