### PR TITLE
Log when GC Notify fails to send an email

### DIFF
--- a/budget-alerts/src/gc_notify.js
+++ b/budget-alerts/src/gc_notify.js
@@ -29,8 +29,16 @@ const sendEmail = async (templateId, emailAddress, options = {}) => {
       message: `An email has been sent to ${emailAddress}. Inspect the notification at ${response?.data?.uri}.`,
     });
     return response;
-  } catch (err) {
-    throw new Error(`Unable to send email to ${emailAddress}`, { cause: err });
+  } catch (error) {
+    // The error is most likely an AxiosError.
+    logger.error({
+      message: `An error occurred sending an email to ${emailAddress}.`,
+      component: {
+        error,
+        body: error?.response?.data,
+      }
+    });
+    throw new Error(`Unable to send email to ${emailAddress}`, { cause: error });
   }
 };
 

--- a/budget-alerts/src/index.js
+++ b/budget-alerts/src/index.js
@@ -266,10 +266,14 @@ const getQueuedBudgetAlertEmails = (events) => {
 
   const result = [];
   for (let i = 0; i < emails.length; i += 1) {
-    if (emails[i].status === 'QUEUED' || emails[i].status === 'FAILED') {
+    // An email that was queued but not tried should be sent.
+    if (emails[i].status === 'QUEUED') {
       delete emails[i].status;
       result.push(emails[i]);
     }
+
+    // An email that failed to send could be retried but the team should decide on system design
+    // with consideration for why the email failed (e.g.: invalid account), and not flooding the system.
   }
   return result;
 };

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -2,7 +2,6 @@
 
 ## Contents
 
-- [Contents](#contents)
 - [About this Document](#about-this-document)
   - [Purpose](#purpose)
   - [Intended Audience](#intended-audience)
@@ -195,6 +194,8 @@ The failing unit tests are skipped to prevent this problem from affecting local 
 In order to focus on higher priority UI features Viewers do not have additional permissions defined in Backstage or in the Templates. This is tracked by [PHACDataHub/sci-portal#464](https://github.com/PHACDataHub/sci-portal/issues/464).
 
 ### Budget Alerts
+
+Budget alert email are sent using [GC Notify](https://documentation.notification.canada.ca/en/send.html#sending-an-email). When sending an email fails the error is logged and not retried again. The system could be made more robust if the team decides how to handle each [error code](https://docs.notifications.service.gov.uk/node.html#send-an-email-error-codes).
 
 As the usage of the Data Science Portal scales, consider replacing the minimum viable solution used to send email notifications. The current solution is documented in the [**budget-alerts/README.md**](https://github.com/PHACDataHub/sci-portal/blob/main/budget-alerts/README.md).
 


### PR DESCRIPTION
### Proposed Changes

- Update the docs
- Log when GC Notify fails to send an email
